### PR TITLE
support for cloud_id and api_key in elasticsearch client

### DIFF
--- a/infra/aws/cloudformation/template.yaml
+++ b/infra/aws/cloudformation/template.yaml
@@ -61,7 +61,7 @@ Metadata:
     Name: elastic-serverless-forwarder
     Description: Elastic Forwared for Serverless
     Author: elastic
-    SemanticVersion: 0.9.3
+    SemanticVersion: 0.10.0
 
 Outputs:
   ElasticServerlessForwarderFunction:

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,7 +6,7 @@ warn_unused_configs = True
 strict = True
 disallow_untyped_defs = True
 no_implicit_reexport = False
-exclude = venv/bin/*.*
+exclude = venv/.*
 
 [mypy-elasticapm.*]
 ignore_missing_imports = True

--- a/share/config.py
+++ b/share/config.py
@@ -41,11 +41,10 @@ class Output(metaclass=ABCMeta):
 
 
 class ElasticSearchOutput(Output):
-    _kwargs = ["hosts", "scheme", "username", "password", "cloud_id", "api_key", "dataset", "namespace"]
+    _kwargs = ["elasticsearch_url", "cloud_id", "username", "password", "api_key", "dataset", "namespace"]
 
     def __init__(self, output_type: str, kwargs: dict[str, Any]):
-        self._hosts: list[str] = []
-        self._scheme: str = ""
+        self._elasticsearch_url: str = ""
         self._username: str = ""
         self._password: str = ""
         self._cloud_id: str = ""
@@ -75,14 +74,11 @@ class ElasticSearchOutput(Output):
             if x in self._kwargs:
                 self.__setattr__(x, value[x])
 
-        if not self.cloud_id and not self.hosts:
-            raise ValueError("Elasticsearch Output hosts or cloud_id must be set")
+        if not self.cloud_id and not self.elasticsearch_url:
+            raise ValueError("Elasticsearch Output elasticsearch_url or cloud_id must be set")
 
-        if self.cloud_id and self.hosts:
-            raise ValueError("Elasticsearch Output only one between hosts and scheme or cloud_id must be set")
-
-        if self.hosts and not self.scheme:
-            raise ValueError("Elasticsearch Output scheme must be set when using hosts")
+        if self.cloud_id and self.elasticsearch_url:
+            raise ValueError("Elasticsearch Output only one between elasticsearch_url or cloud_id must be set")
 
         if not self.username and not self.api_key:
             raise ValueError("Elasticsearch Output username and password or api_key must be set")
@@ -100,26 +96,15 @@ class ElasticSearchOutput(Output):
             raise ValueError("Empty param namespace provided for Elasticsearch Output")
 
     @property
-    def hosts(self) -> list[str]:
-        return self._hosts
+    def elasticsearch_url(self) -> str:
+        return self._elasticsearch_url
 
-    @hosts.setter
-    def hosts(self, value: list[str]) -> None:
-        if not isinstance(value, list):
-            raise ValueError("Elasticsearch Output hosts must be of type list[str]")
-
-        self._hosts = value
-
-    @property
-    def scheme(self) -> str:
-        return self._scheme
-
-    @scheme.setter
-    def scheme(self, value: str) -> None:
+    @elasticsearch_url.setter
+    def elasticsearch_url(self, value: str) -> None:
         if not isinstance(value, str):
-            raise ValueError("Elasticsearch Output scheme must be of type str")
+            raise ValueError("Elasticsearch Output elasticsearch_url must be of type str")
 
-        self._scheme = value
+        self._elasticsearch_url = value
 
     @property
     def username(self) -> str:

--- a/share/config.py
+++ b/share/config.py
@@ -7,6 +7,8 @@ from typing import Any, Optional
 
 import yaml
 
+from .logger import logger as shared_logger
+
 _available_input_types: list[str] = ["sqs"]
 _available_output_types: list[str] = ["elasticsearch"]
 
@@ -78,22 +80,27 @@ class ElasticSearchOutput(Output):
             raise ValueError("Elasticsearch Output elasticsearch_url or cloud_id must be set")
 
         if self.cloud_id and self.elasticsearch_url:
-            raise ValueError("Elasticsearch Output only one between elasticsearch_url or cloud_id must be set")
+            shared_logger.warn("both elasticsearch_url and cloud_id set in config: using cloud_id")
+            self.elasticsearch_url = ""
 
         if not self.username and not self.api_key:
             raise ValueError("Elasticsearch Output username and password or api_key must be set")
 
         if self.username and self.api_key:
-            raise ValueError("Elasticsearch Output only one between username and password or api_key must be set")
+            shared_logger.warn("both api_key and username and password set in config: using api_key")
+            self._username = ""
+            self._password = ""
 
         if self.username and not self.password:
             raise ValueError("Elasticsearch Output password must be set when using username")
 
         if not self.dataset:
-            raise ValueError("Empty param dataset provided for Elasticsearch Output")
+            shared_logger.warn("no dataset set in config: using `generic`")
+            self.dataset = "generic"
 
         if not self.namespace:
-            raise ValueError("Empty param namespace provided for Elasticsearch Output")
+            shared_logger.warn("no namespace set in config: using `default`")
+            self.namespace = "default"
 
     @property
     def elasticsearch_url(self) -> str:

--- a/share/config.py
+++ b/share/config.py
@@ -2,7 +2,6 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-import json
 from abc import ABCMeta, abstractmethod
 from typing import Any, Optional
 

--- a/shippers/es.py
+++ b/shippers/es.py
@@ -17,8 +17,7 @@ class ElasticsearchShipper(CommonShipper):
 
     def __init__(
         self,
-        hosts: list[str] = [],
-        scheme: str = "",
+        elasticsearch_url: str = "",
         username: str = "",
         password: str = "",
         cloud_id: str = "",
@@ -30,13 +29,12 @@ class ElasticsearchShipper(CommonShipper):
         self._bulk_actions: list[dict[str, Any]] = []
 
         es_client_kwargs: dict[str, Any] = {}
-        if hosts:
-            es_client_kwargs["hosts"] = hosts
-            es_client_kwargs["scheme"] = scheme
+        if elasticsearch_url:
+            es_client_kwargs["hosts"] = [elasticsearch_url]
         elif cloud_id:
             es_client_kwargs["cloud_id"] = cloud_id
         else:
-            raise ValueError("You must provide one between hosts and scheme or cloud_id")
+            raise ValueError("You must provide one between elasticsearch_url or cloud_id")
 
         if username:
             es_client_kwargs["http_auth"] = (username, password)

--- a/shippers/es.py
+++ b/shippers/es.py
@@ -15,14 +15,31 @@ from .shipper import CommonShipper
 class ElasticsearchShipper(CommonShipper):
     _bulk_batch_size: int = 10000
 
-    def __init__(self, hosts: list[str], username: str, password: str, scheme: str, dataset: str, namespace: str):
+    def __init__(self, hosts: list[str] = [], scheme: str = "",
+                 username: str = "", password: str = "",
+                 cloud_id: str = "", api_key: str = "",
+                 dataset: str = "", namespace: str = ""):
+
         self._bulk_actions: list[dict[str, Any]] = []
 
-        self._es_client = Elasticsearch(
-            hosts,
-            http_auth=(username, password),
-            scheme=scheme,
-        )
+        es_client_kwargs: dict[str, Any] = {}
+        if hosts:
+            es_client_kwargs["hosts"] = hosts
+            es_client_kwargs["scheme"] = scheme
+        elif cloud_id:
+            es_client_kwargs["cloud_id"] = cloud_id
+        else:
+            raise ValueError("You must provide one between hosts and scheme or cloud_id")
+
+        if username:
+            es_client_kwargs["http_auth"] = (username, password)
+
+        elif api_key:
+            es_client_kwargs["api_key"] = api_key
+        else:
+            raise ValueError("You must provide one between username and password or api_key")
+
+        self._es_client = Elasticsearch(**es_client_kwargs)
 
         self._dataset = dataset
         self._namespace = namespace

--- a/shippers/es.py
+++ b/shippers/es.py
@@ -15,10 +15,17 @@ from .shipper import CommonShipper
 class ElasticsearchShipper(CommonShipper):
     _bulk_batch_size: int = 10000
 
-    def __init__(self, hosts: list[str] = [], scheme: str = "",
-                 username: str = "", password: str = "",
-                 cloud_id: str = "", api_key: str = "",
-                 dataset: str = "", namespace: str = ""):
+    def __init__(
+        self,
+        hosts: list[str] = [],
+        scheme: str = "",
+        username: str = "",
+        password: str = "",
+        cloud_id: str = "",
+        api_key: str = "",
+        dataset: str = "",
+        namespace: str = "",
+    ):
 
         self._bulk_actions: list[dict[str, Any]] = []
 

--- a/shippers/factory.py
+++ b/shippers/factory.py
@@ -23,8 +23,7 @@ class ShipperFactory:
             elasticsearch_output = ElasticSearchOutput(output.type, output.kwargs)
             return ShipperFactory.create(
                 output="elasticsearch",
-                hosts=elasticsearch_output.hosts,
-                scheme=elasticsearch_output.scheme,
+                elasticsearch_url=elasticsearch_output.elasticsearch_url,
                 username=elasticsearch_output.username,
                 password=elasticsearch_output.password,
                 cloud_id=elasticsearch_output.cloud_id,

--- a/shippers/factory.py
+++ b/shippers/factory.py
@@ -2,7 +2,6 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-import json
 from typing import Any, Callable
 
 from share.config import ElasticSearchOutput, Output

--- a/shippers/factory.py
+++ b/shippers/factory.py
@@ -13,7 +13,6 @@ from .shipper import CommonShipper
 _init_definition_by_output: dict[str, dict[str, Any]] = {
     "elasticsearch": {
         "class": ElasticsearchShipper,
-        "kwargs": ["hosts", "scheme", "username", "password", "dataset", "namespace"],
     }
 }
 
@@ -29,6 +28,8 @@ class ShipperFactory:
                 scheme=elasticsearch_output.scheme,
                 username=elasticsearch_output.username,
                 password=elasticsearch_output.password,
+                cloud_id=elasticsearch_output.cloud_id,
+                api_key=elasticsearch_output.api_key,
                 dataset=elasticsearch_output.dataset,
                 namespace=elasticsearch_output.namespace,
             )
@@ -46,14 +47,6 @@ class ShipperFactory:
 
         output_definition = _init_definition_by_output[output]
 
-        output_kwargs = output_definition["kwargs"]
         output_builder: Callable[..., CommonShipper] = output_definition["class"]
-
-        init_kwargs: list[str] = [key for key in kwargs.keys() if key in output_kwargs and kwargs[key]]
-        if len(init_kwargs) != len(output_kwargs):
-            raise ValueError(
-                f"you must provide the following not empty init kwargs for {output}:"
-                f" {', '.join(output_kwargs)}. (provided: {json.dumps(kwargs)})"
-            )
 
         return output_builder(**kwargs)

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -19,4 +19,4 @@ docker run \
   /bin/bash \
   -c "pip install --user -U pip
       pip install --user -r tests/requirements/requirements.txt --cache-dir ${docker_pip_cache}
-      timeout 5m /bin/bash ./tests/scripts/run_tests.sh"
+      timeout 15m /bin/bash ./tests/scripts/run_tests.sh"

--- a/tests/share/test_config.py
+++ b/tests/share/test_config.py
@@ -195,9 +195,7 @@ class TestElasticSearchOutput(TestCase):
                 ElasticSearchOutput(output_type="type", kwargs={})
 
         with self.subTest("neither hosts or cloud_id"):
-            with self.assertRaisesRegex(
-                ValueError, "Elasticsearch Output hosts or cloud_id must be set"
-            ):
+            with self.assertRaisesRegex(ValueError, "Elasticsearch Output hosts or cloud_id must be set"):
                 ElasticSearchOutput(output_type="elasticsearch", kwargs={})
 
         with self.subTest("both hosts and cloud_id"):
@@ -207,7 +205,9 @@ class TestElasticSearchOutput(TestCase):
                 ElasticSearchOutput(output_type="elasticsearch", kwargs={"hosts": ["hosts"], "cloud_id": "cloud_id"})
 
         with self.subTest("no username or api_key"):
-            with self.assertRaisesRegex(ValueError, "Elasticsearch Output username and password or api_key must be set"):
+            with self.assertRaisesRegex(
+                ValueError, "Elasticsearch Output username and password or api_key must be set"
+            ):
                 ElasticSearchOutput(
                     output_type="elasticsearch",
                     kwargs={
@@ -219,7 +219,9 @@ class TestElasticSearchOutput(TestCase):
                 )
 
         with self.subTest("both username and api_key"):
-            with self.assertRaisesRegex(ValueError, "Elasticsearch Output only one between username and password or api_key must be set"):
+            with self.assertRaisesRegex(
+                ValueError, "Elasticsearch Output only one between username and password or api_key must be set"
+            ):
                 ElasticSearchOutput(
                     output_type="elasticsearch",
                     kwargs={
@@ -755,9 +757,7 @@ class TestParseConfig(TestCase):
             """
                 )
 
-            with self.assertRaisesRegex(
-                ValueError, "Elasticsearch Output hosts or cloud_id must be set"
-            ):
+            with self.assertRaisesRegex(ValueError, "Elasticsearch Output hosts or cloud_id must be set"):
                 parse_config(
                     config_yaml="""
             inputs:
@@ -838,7 +838,6 @@ class TestParseConfig(TestCase):
             assert elasticsearch.api_key == "api_key"
             assert elasticsearch.dataset == "dataset"
             assert elasticsearch.namespace == "namespace"
-
 
         with self.subTest("valid input valid elasticsearch output with cloud id and http auth"):
             config = parse_config(

--- a/tests/share/test_config.py
+++ b/tests/share/test_config.py
@@ -70,12 +70,11 @@ class TestOutput(TestCase):
 
 class TestElasticSearchOutput(TestCase):
     def test_init(self) -> None:
-        with self.subTest("valid init with hosts and http_auth"):
+        with self.subTest("valid init with elasticsearch_url and http_auth"):
             elasticsearch = ElasticSearchOutput(
                 output_type="elasticsearch",
                 kwargs={
-                    "hosts": ["hosts"],
-                    "scheme": "scheme",
+                    "elasticsearch_url": "elasticsearch_url",
                     "username": "username",
                     "password": "password",
                     "dataset": "dataset",
@@ -85,8 +84,7 @@ class TestElasticSearchOutput(TestCase):
             )
 
             assert elasticsearch.type == "elasticsearch"
-            assert elasticsearch.hosts == ["hosts"]
-            assert elasticsearch.scheme == "scheme"
+            assert elasticsearch.elasticsearch_url == "elasticsearch_url"
             assert elasticsearch.username == "username"
             assert elasticsearch.password == "password"
             assert not elasticsearch.cloud_id
@@ -94,8 +92,7 @@ class TestElasticSearchOutput(TestCase):
             assert elasticsearch.dataset == "dataset"
             assert elasticsearch.namespace == "namespace"
             assert elasticsearch.kwargs == {
-                "hosts": ["hosts"],
-                "scheme": "scheme",
+                "elasticsearch_url": "elasticsearch_url",
                 "username": "username",
                 "password": "password",
                 "dataset": "dataset",
@@ -119,8 +116,7 @@ class TestElasticSearchOutput(TestCase):
             assert elasticsearch.cloud_id == "cloud_id"
             assert elasticsearch.username == "username"
             assert elasticsearch.password == "password"
-            assert not elasticsearch.hosts
-            assert not elasticsearch.scheme
+            assert not elasticsearch.elasticsearch_url
             assert not elasticsearch.api_key
             assert elasticsearch.dataset == "dataset"
             assert elasticsearch.namespace == "namespace"
@@ -132,12 +128,11 @@ class TestElasticSearchOutput(TestCase):
                 "namespace": "namespace",
             }
 
-        with self.subTest("valid init with hosts and api key"):
+        with self.subTest("valid init with elasticsearch_url and api key"):
             elasticsearch = ElasticSearchOutput(
                 output_type="elasticsearch",
                 kwargs={
-                    "hosts": ["hosts"],
-                    "scheme": "scheme",
+                    "elasticsearch_url": "elasticsearch_url",
                     "api_key": "api_key",
                     "dataset": "dataset",
                     "namespace": "namespace",
@@ -146,8 +141,7 @@ class TestElasticSearchOutput(TestCase):
             )
 
             assert elasticsearch.type == "elasticsearch"
-            assert elasticsearch.hosts == ["hosts"]
-            assert elasticsearch.scheme == "scheme"
+            assert elasticsearch.elasticsearch_url == "elasticsearch_url"
             assert elasticsearch.api_key == "api_key"
             assert not elasticsearch.cloud_id
             assert not elasticsearch.username
@@ -155,8 +149,7 @@ class TestElasticSearchOutput(TestCase):
             assert elasticsearch.dataset == "dataset"
             assert elasticsearch.namespace == "namespace"
             assert elasticsearch.kwargs == {
-                "hosts": ["hosts"],
-                "scheme": "scheme",
+                "elasticsearch_url": "elasticsearch_url",
                 "api_key": "api_key",
                 "dataset": "dataset",
                 "namespace": "namespace",
@@ -177,8 +170,7 @@ class TestElasticSearchOutput(TestCase):
             assert elasticsearch.type == "elasticsearch"
             assert elasticsearch.cloud_id == "cloud_id"
             assert elasticsearch.api_key == "api_key"
-            assert not elasticsearch.hosts
-            assert not elasticsearch.scheme
+            assert not elasticsearch.elasticsearch_url
             assert not elasticsearch.username
             assert not elasticsearch.password
             assert elasticsearch.dataset == "dataset"
@@ -194,15 +186,18 @@ class TestElasticSearchOutput(TestCase):
             with self.assertRaisesRegex(ValueError, "output_type for ElasticSearchOutput must be elasticsearch"):
                 ElasticSearchOutput(output_type="type", kwargs={})
 
-        with self.subTest("neither hosts or cloud_id"):
-            with self.assertRaisesRegex(ValueError, "Elasticsearch Output hosts or cloud_id must be set"):
+        with self.subTest("neither elasticsearch_url or cloud_id"):
+            with self.assertRaisesRegex(ValueError, "Elasticsearch Output elasticsearch_url or cloud_id must be set"):
                 ElasticSearchOutput(output_type="elasticsearch", kwargs={})
 
-        with self.subTest("both hosts and cloud_id"):
+        with self.subTest("both elasticsearch_url and cloud_id"):
             with self.assertRaisesRegex(
-                ValueError, "Elasticsearch Output only one between hosts and scheme or cloud_id must be set"
+                ValueError, "Elasticsearch Output only one between elasticsearch_url or cloud_id must be set"
             ):
-                ElasticSearchOutput(output_type="elasticsearch", kwargs={"hosts": ["hosts"], "cloud_id": "cloud_id"})
+                ElasticSearchOutput(
+                    output_type="elasticsearch",
+                    kwargs={"elasticsearch_url": "elasticsearch_url", "cloud_id": "cloud_id"},
+                )
 
         with self.subTest("no username or api_key"):
             with self.assertRaisesRegex(
@@ -211,8 +206,7 @@ class TestElasticSearchOutput(TestCase):
                 ElasticSearchOutput(
                     output_type="elasticsearch",
                     kwargs={
-                        "hosts": ["hosts"],
-                        "scheme": "scheme",
+                        "elasticsearch_url": "elasticsearch_url",
                         "dataset": "dataset",
                         "namespace": "namespace",
                     },
@@ -225,8 +219,7 @@ class TestElasticSearchOutput(TestCase):
                 ElasticSearchOutput(
                     output_type="elasticsearch",
                     kwargs={
-                        "hosts": ["hosts"],
-                        "scheme": "scheme",
+                        "elasticsearch_url": "elasticsearch_url",
                         "username": "username",
                         "api_key": "api_key",
                         "dataset": "dataset",
@@ -239,8 +232,7 @@ class TestElasticSearchOutput(TestCase):
                 ElasticSearchOutput(
                     output_type="elasticsearch",
                     kwargs={
-                        "hosts": ["hosts"],
-                        "scheme": "scheme",
+                        "elasticsearch_url": "elasticsearch_url",
                         "username": "username",
                         "password": "",
                         "dataset": "dataset",
@@ -253,8 +245,7 @@ class TestElasticSearchOutput(TestCase):
                 ElasticSearchOutput(
                     output_type="elasticsearch",
                     kwargs={
-                        "hosts": ["hosts"],
-                        "scheme": "scheme",
+                        "elasticsearch_url": "elasticsearch_url",
                         "username": "username",
                         "password": "password",
                         "dataset": "",
@@ -267,8 +258,7 @@ class TestElasticSearchOutput(TestCase):
                 ElasticSearchOutput(
                     output_type="elasticsearch",
                     kwargs={
-                        "hosts": ["hosts"],
-                        "scheme": "scheme",
+                        "elasticsearch_url": "elasticsearch_url",
                         "username": "username",
                         "password": "password",
                         "dataset": "dataset",
@@ -276,41 +266,14 @@ class TestElasticSearchOutput(TestCase):
                     },
                 )
 
-        with self.subTest("empty scheme"):
-            with self.assertRaisesRegex(ValueError, "Elasticsearch Output scheme must be set when using hosts"):
+        with self.subTest("elasticsearch_url not str"):
+            with self.assertRaisesRegex(
+                ValueError, re.escape("Elasticsearch Output elasticsearch_url must be of type str")
+            ):
                 ElasticSearchOutput(
                     output_type="elasticsearch",
                     kwargs={
-                        "hosts": ["hosts"],
-                        "scheme": "",
-                        "username": "username",
-                        "password": "password",
-                        "dataset": "dataset",
-                        "namespace": "namespace",
-                    },
-                )
-
-        with self.subTest("hosts not list"):
-            with self.assertRaisesRegex(ValueError, re.escape("Elasticsearch Output hosts must be of type list[str]")):
-                ElasticSearchOutput(
-                    output_type="elasticsearch",
-                    kwargs={
-                        "hosts": "",
-                        "scheme": "scheme",
-                        "username": "username",
-                        "password": "password",
-                        "dataset": "dataset",
-                        "namespace": "namespace",
-                    },
-                )
-
-        with self.subTest("scheme not str"):
-            with self.assertRaisesRegex(ValueError, "Elasticsearch Output scheme must be of type str"):
-                ElasticSearchOutput(
-                    output_type="elasticsearch",
-                    kwargs={
-                        "hosts": ["hosts"],
-                        "scheme": 0,
+                        "elasticsearch_url": 0,
                         "username": "username",
                         "password": "password",
                         "dataset": "dataset",
@@ -323,8 +286,7 @@ class TestElasticSearchOutput(TestCase):
                 ElasticSearchOutput(
                     output_type="elasticsearch",
                     kwargs={
-                        "hosts": ["hosts"],
-                        "scheme": "scheme",
+                        "elasticsearch_url": "",
                         "username": 0,
                         "password": "password",
                         "dataset": "dataset",
@@ -337,8 +299,7 @@ class TestElasticSearchOutput(TestCase):
                 ElasticSearchOutput(
                     output_type="elasticsearch",
                     kwargs={
-                        "hosts": ["hosts"],
-                        "scheme": "scheme",
+                        "elasticsearch_url": "",
                         "username": "username",
                         "password": 0,
                         "dataset": "dataset",
@@ -376,8 +337,7 @@ class TestElasticSearchOutput(TestCase):
                 ElasticSearchOutput(
                     output_type="elasticsearch",
                     kwargs={
-                        "hosts": ["hosts"],
-                        "scheme": "scheme",
+                        "elasticsearch_url": "",
                         "username": "username",
                         "password": "password",
                         "dataset": 0,
@@ -390,8 +350,7 @@ class TestElasticSearchOutput(TestCase):
                 ElasticSearchOutput(
                     output_type="elasticsearch",
                     kwargs={
-                        "hosts": ["hosts"],
-                        "scheme": "scheme",
+                        "elasticsearch_url": "",
                         "username": "username",
                         "password": "password",
                         "dataset": "dataset",
@@ -404,8 +363,7 @@ class TestElasticSearchOutput(TestCase):
             elasticsearch = ElasticSearchOutput(
                 output_type="elasticsearch",
                 kwargs={
-                    "hosts": ["hosts"],
-                    "scheme": "scheme",
+                    "elasticsearch_url": "elasticsearch_url",
                     "username": "username",
                     "password": "password",
                     "dataset": "dataset",
@@ -414,9 +372,8 @@ class TestElasticSearchOutput(TestCase):
                 },
             )
 
-            elasticsearch.scheme = ""
             assert elasticsearch.kwargs == {
-                "hosts": ["hosts"],
+                "elasticsearch_url": "elasticsearch_url",
                 "username": "username",
                 "password": "password",
                 "dataset": "dataset",
@@ -457,8 +414,7 @@ class TestInput(TestCase):
             input_sqs.add_output(
                 output_type="elasticsearch",
                 output_kwargs={
-                    "hosts": ["hosts"],
-                    "scheme": "scheme",
+                    "elasticsearch_url": "elasticsearch_url",
                     "username": "username",
                     "password": "password",
                     "dataset": "dataset",
@@ -474,8 +430,7 @@ class TestInput(TestCase):
             input_sqs.add_output(
                 output_type="elasticsearch",
                 output_kwargs={
-                    "hosts": ["hosts"],
-                    "scheme": "scheme",
+                    "elasticsearch_url": "elasticsearch_url",
                     "username": "username",
                     "password": "password",
                     "dataset": "dataset",
@@ -505,8 +460,7 @@ class TestInput(TestCase):
             input_sqs.add_output(
                 output_type="elasticsearch",
                 output_kwargs={
-                    "hosts": ["hosts"],
-                    "scheme": "scheme",
+                    "elasticsearch_url": "elasticsearch_url",
                     "username": "username",
                     "password": "password",
                     "dataset": "dataset",
@@ -518,8 +472,7 @@ class TestInput(TestCase):
                 input_sqs.add_output(
                     output_type="elasticsearch",
                     output_kwargs={
-                        "hosts": ["hosts"],
-                        "scheme": "scheme",
+                        "elasticsearch_url": "elasticsearch_url",
                         "username": "username",
                         "password": "password",
                         "dataset": "dataset",
@@ -537,8 +490,7 @@ class TestInput(TestCase):
             input_sqs.add_output(
                 output_type="elasticsearch",
                 output_kwargs={
-                    "hosts": ["hosts"],
-                    "scheme": "scheme",
+                    "elasticsearch_url": "elasticsearch_url",
                     "username": "username",
                     "password": "password",
                     "dataset": "dataset",
@@ -554,8 +506,7 @@ class TestInput(TestCase):
             input_sqs.add_output(
                 output_type="elasticsearch",
                 output_kwargs={
-                    "hosts": ["hosts"],
-                    "scheme": "scheme",
+                    "elasticsearch_url": "elasticsearch_url",
                     "username": "username",
                     "password": "password",
                     "dataset": "dataset",
@@ -757,7 +708,7 @@ class TestParseConfig(TestCase):
             """
                 )
 
-            with self.assertRaisesRegex(ValueError, "Elasticsearch Output hosts or cloud_id must be set"):
+            with self.assertRaisesRegex(ValueError, "Elasticsearch Output elasticsearch_url or cloud_id must be set"):
                 parse_config(
                     config_yaml="""
             inputs:
@@ -769,7 +720,7 @@ class TestParseConfig(TestCase):
             """
                 )
 
-        with self.subTest("valid input valid elasticsearch output with hosts and http auth"):
+        with self.subTest("valid input valid elasticsearch output with elasticsearch_url and http auth"):
             config = parse_config(
                 config_yaml="""
             inputs:
@@ -778,9 +729,7 @@ class TestParseConfig(TestCase):
                 outputs:
                   - type: elasticsearch
                     args:
-                      hosts:
-                        - "hosts"
-                      scheme: "scheme"
+                      elasticsearch_url: "elasticsearch_url"
                       username: "username"
                       password: "password"
                       dataset: "dataset"
@@ -798,14 +747,13 @@ class TestParseConfig(TestCase):
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticSearchOutput)
             assert elasticsearch.type == "elasticsearch"
-            assert elasticsearch.hosts == ["hosts"]
-            assert elasticsearch.scheme == "scheme"
+            assert elasticsearch.elasticsearch_url == "elasticsearch_url"
             assert elasticsearch.username == "username"
             assert elasticsearch.password == "password"
             assert elasticsearch.dataset == "dataset"
             assert elasticsearch.namespace == "namespace"
 
-        with self.subTest("valid input valid elasticsearch output with hosts and api key"):
+        with self.subTest("valid input valid elasticsearch output with elasticsearch_url and api key"):
             config = parse_config(
                 config_yaml="""
             inputs:
@@ -814,9 +762,7 @@ class TestParseConfig(TestCase):
                 outputs:
                   - type: elasticsearch
                     args:
-                      hosts:
-                        - "hosts"
-                      scheme: "scheme"
+                      elasticsearch_url: "elasticsearch_url"
                       api_key: "api_key"
                       dataset: "dataset"
                       namespace: "namespace"
@@ -833,8 +779,7 @@ class TestParseConfig(TestCase):
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticSearchOutput)
             assert elasticsearch.type == "elasticsearch"
-            assert elasticsearch.hosts == ["hosts"]
-            assert elasticsearch.scheme == "scheme"
+            assert elasticsearch.elasticsearch_url == "elasticsearch_url"
             assert elasticsearch.api_key == "api_key"
             assert elasticsearch.dataset == "dataset"
             assert elasticsearch.namespace == "namespace"
@@ -872,7 +817,7 @@ class TestParseConfig(TestCase):
             assert elasticsearch.dataset == "dataset"
             assert elasticsearch.namespace == "namespace"
 
-        with self.subTest("valid input valid elasticsearch output cloud_id hosts and api key"):
+        with self.subTest("valid input valid elasticsearch output cloud_id and api key"):
             config = parse_config(
                 config_yaml="""
             inputs:
@@ -882,7 +827,6 @@ class TestParseConfig(TestCase):
                   - type: elasticsearch
                     args:
                       cloud_id: "cloud_id"
-                      scheme: "scheme"
                       api_key: "api_key"
                       dataset: "dataset"
                       namespace: "namespace"

--- a/tests/share/test_config.py
+++ b/tests/share/test_config.py
@@ -191,13 +191,32 @@ class TestElasticSearchOutput(TestCase):
                 ElasticSearchOutput(output_type="elasticsearch", kwargs={})
 
         with self.subTest("both elasticsearch_url and cloud_id"):
-            with self.assertRaisesRegex(
-                ValueError, "Elasticsearch Output only one between elasticsearch_url or cloud_id must be set"
-            ):
-                ElasticSearchOutput(
-                    output_type="elasticsearch",
-                    kwargs={"elasticsearch_url": "elasticsearch_url", "cloud_id": "cloud_id"},
-                )
+            elasticsearch = ElasticSearchOutput(
+                output_type="elasticsearch",
+                kwargs={
+                    "elasticsearch_url": "elasticsearch_url",
+                    "cloud_id": "cloud_id",
+                    "api_key": "api_key",
+                    "dataset": "dataset",
+                    "namespace": "namespace",
+                    "ignored": "ignored",
+                },
+            )
+
+            assert elasticsearch.type == "elasticsearch"
+            assert elasticsearch.cloud_id == "cloud_id"
+            assert elasticsearch.api_key == "api_key"
+            assert not elasticsearch.elasticsearch_url
+            assert not elasticsearch.username
+            assert not elasticsearch.password
+            assert elasticsearch.dataset == "dataset"
+            assert elasticsearch.namespace == "namespace"
+            assert elasticsearch.kwargs == {
+                "api_key": "api_key",
+                "cloud_id": "cloud_id",
+                "dataset": "dataset",
+                "namespace": "namespace",
+            }
 
         with self.subTest("no username or api_key"):
             with self.assertRaisesRegex(
@@ -213,19 +232,33 @@ class TestElasticSearchOutput(TestCase):
                 )
 
         with self.subTest("both username and api_key"):
-            with self.assertRaisesRegex(
-                ValueError, "Elasticsearch Output only one between username and password or api_key must be set"
-            ):
-                ElasticSearchOutput(
-                    output_type="elasticsearch",
-                    kwargs={
-                        "elasticsearch_url": "elasticsearch_url",
-                        "username": "username",
-                        "api_key": "api_key",
-                        "dataset": "dataset",
-                        "namespace": "namespace",
-                    },
-                )
+            elasticsearch = ElasticSearchOutput(
+                output_type="elasticsearch",
+                kwargs={
+                    "cloud_id": "cloud_id",
+                    "api_key": "api_key",
+                    "username": "username",
+                    "password": "password",
+                    "dataset": "dataset",
+                    "namespace": "namespace",
+                    "ignored": "ignored",
+                },
+            )
+
+            assert elasticsearch.type == "elasticsearch"
+            assert elasticsearch.cloud_id == "cloud_id"
+            assert elasticsearch.api_key == "api_key"
+            assert not elasticsearch.elasticsearch_url
+            assert not elasticsearch.username
+            assert not elasticsearch.password
+            assert elasticsearch.dataset == "dataset"
+            assert elasticsearch.namespace == "namespace"
+            assert elasticsearch.kwargs == {
+                "cloud_id": "cloud_id",
+                "api_key": "api_key",
+                "dataset": "dataset",
+                "namespace": "namespace",
+            }
 
         with self.subTest("empty password"):
             with self.assertRaisesRegex(ValueError, "Elasticsearch Output password must be set when using username"):
@@ -241,30 +274,60 @@ class TestElasticSearchOutput(TestCase):
                 )
 
         with self.subTest("empty dataset"):
-            with self.assertRaisesRegex(ValueError, "Empty param dataset provided for Elasticsearch Output"):
-                ElasticSearchOutput(
-                    output_type="elasticsearch",
-                    kwargs={
-                        "elasticsearch_url": "elasticsearch_url",
-                        "username": "username",
-                        "password": "password",
-                        "dataset": "",
-                        "namespace": "namespace",
-                    },
-                )
+            elasticsearch = ElasticSearchOutput(
+                output_type="elasticsearch",
+                kwargs={
+                    "cloud_id": "cloud_id",
+                    "api_key": "api_key",
+                    "username": "username",
+                    "password": "password",
+                    "namespace": "namespace",
+                    "ignored": "ignored",
+                },
+            )
+
+            assert elasticsearch.type == "elasticsearch"
+            assert elasticsearch.cloud_id == "cloud_id"
+            assert elasticsearch.api_key == "api_key"
+            assert not elasticsearch.elasticsearch_url
+            assert not elasticsearch.username
+            assert not elasticsearch.password
+            assert elasticsearch.dataset == "generic"
+            assert elasticsearch.namespace == "namespace"
+            assert elasticsearch.kwargs == {
+                "cloud_id": "cloud_id",
+                "api_key": "api_key",
+                "dataset": "generic",
+                "namespace": "namespace",
+            }
 
         with self.subTest("empty namespace"):
-            with self.assertRaisesRegex(ValueError, "Empty param namespace provided for Elasticsearch Output"):
-                ElasticSearchOutput(
-                    output_type="elasticsearch",
-                    kwargs={
-                        "elasticsearch_url": "elasticsearch_url",
-                        "username": "username",
-                        "password": "password",
-                        "dataset": "dataset",
-                        "namespace": "",
-                    },
-                )
+            elasticsearch = ElasticSearchOutput(
+                output_type="elasticsearch",
+                kwargs={
+                    "cloud_id": "cloud_id",
+                    "api_key": "api_key",
+                    "username": "username",
+                    "password": "password",
+                    "dataset": "dataset",
+                    "ignored": "ignored",
+                },
+            )
+
+            assert elasticsearch.type == "elasticsearch"
+            assert elasticsearch.cloud_id == "cloud_id"
+            assert elasticsearch.api_key == "api_key"
+            assert not elasticsearch.elasticsearch_url
+            assert not elasticsearch.username
+            assert not elasticsearch.password
+            assert elasticsearch.dataset == "dataset"
+            assert elasticsearch.namespace == "default"
+            assert elasticsearch.kwargs == {
+                "cloud_id": "cloud_id",
+                "api_key": "api_key",
+                "dataset": "dataset",
+                "namespace": "default",
+            }
 
         with self.subTest("elasticsearch_url not str"):
             with self.assertRaisesRegex(

--- a/tests/shippers/test_es.py
+++ b/tests/shippers/test_es.py
@@ -67,7 +67,7 @@ class TestElasticsearchShipper(TestCase):
     def test_send(self) -> None:
         ElasticsearchShipper._bulk_batch_size = 0
         shipper = ElasticsearchShipper(
-            hosts=[""], username="", password="", scheme="", dataset="data.set", namespace="namespace"
+            hosts=["hosts"], username="username", password="", scheme="", dataset="data.set", namespace="namespace"
         )
         es_event = deepcopy(_dummy_event)
         shipper.send(es_event)
@@ -106,7 +106,7 @@ class TestElasticsearchShipper(TestCase):
     def test_flush(self) -> None:
         ElasticsearchShipper._bulk_batch_size = 2
         shipper = ElasticsearchShipper(
-            hosts=[""], username="", password="", scheme="", dataset="data.set", namespace="namespace"
+            hosts=["hosts"], username="username", password="", scheme="", dataset="data.set", namespace="namespace"
         )
         es_event = deepcopy(_dummy_event)
         shipper.send(es_event)

--- a/tests/shippers/test_es.py
+++ b/tests/shippers/test_es.py
@@ -67,7 +67,11 @@ class TestElasticsearchShipper(TestCase):
     def test_send(self) -> None:
         ElasticsearchShipper._bulk_batch_size = 0
         shipper = ElasticsearchShipper(
-            hosts=["hosts"], username="username", password="", scheme="", dataset="data.set", namespace="namespace"
+            elasticsearch_url="elasticsearch_url",
+            username="username",
+            password="",
+            dataset="data.set",
+            namespace="namespace",
         )
         es_event = deepcopy(_dummy_event)
         shipper.send(es_event)
@@ -106,7 +110,11 @@ class TestElasticsearchShipper(TestCase):
     def test_flush(self) -> None:
         ElasticsearchShipper._bulk_batch_size = 2
         shipper = ElasticsearchShipper(
-            hosts=["hosts"], username="username", password="", scheme="", dataset="data.set", namespace="namespace"
+            elasticsearch_url="elasticsearch_url",
+            username="username",
+            password="",
+            dataset="data.set",
+            namespace="namespace",
         )
         es_event = deepcopy(_dummy_event)
         shipper.send(es_event)

--- a/tests/shippers/test_factory.py
+++ b/tests/shippers/test_factory.py
@@ -11,7 +11,7 @@ from shippers import CommonShipper, ElasticsearchShipper, ShipperFactory
 
 class TestShipperFactory(TestCase):
     def test_create(self) -> None:
-        with self.subTest("create elasticsearch shipper success"):
+        with self.subTest("create elasticsearch shipper success hosts and http auth"):
             shipper: CommonShipper = ShipperFactory.create(
                 output="elasticsearch",
                 hosts=["hosts"],
@@ -24,25 +24,70 @@ class TestShipperFactory(TestCase):
 
             assert isinstance(shipper, ElasticsearchShipper)
 
-        with self.subTest("create elasticsearch shipper error"):
+        with self.subTest("create elasticsearch shipper success hosts and api key"):
+            shipper: CommonShipper = ShipperFactory.create(
+                output="elasticsearch",
+                hosts=["hosts"],
+                scheme="scheme",
+                api_key="api_key",
+                dataset="dataset",
+                namespace="namespace",
+            )
+
+            assert isinstance(shipper, ElasticsearchShipper)
+
+        with self.subTest("create elasticsearch shipper success cloud id and http auth"):
+            shipper: CommonShipper = ShipperFactory.create(
+                output="elasticsearch",
+                cloud_id="cloud_id:bG9jYWxob3N0OjkyMDAkMA==",
+                username="username",
+                password="password",
+                dataset="dataset",
+                namespace="namespace",
+            )
+
+            assert isinstance(shipper, ElasticsearchShipper)
+
+        with self.subTest("create elasticsearch shipper success cloud id and api key"):
+            shipper: CommonShipper = ShipperFactory.create(
+                output="elasticsearch",
+                cloud_id="cloud_id:bG9jYWxob3N0OjkyMDAkMA==",
+                api_key="api_key",
+                dataset="dataset",
+                namespace="namespace",
+            )
+
+            assert isinstance(shipper, ElasticsearchShipper)
+        with self.subTest("create elasticsearch shipper no kwargs error"):
             with self.assertRaisesRegex(
-                ValueError,
-                re.escape(
-                    "you must provide the following not empty init kwargs for elasticsearch: hosts, scheme, username,"
-                    + " password, dataset, namespace. (provided: {})"
-                ),
+                ValueError, "You must provide one between hosts and scheme or cloud_id"
             ):
                 ShipperFactory.create(output="elasticsearch")
 
-        with self.subTest("create elasticsearch shipper empty kwargs"):
+        with self.subTest("create elasticsearch shipper empty hosts and no cloud_id"):
             with self.assertRaisesRegex(
-                ValueError,
-                re.escape(
-                    "you must provide the following not empty init kwargs for elasticsearch: hosts, scheme, username,"
-                    + ' password, dataset, namespace. (provided: {"hosts": []})'
-                ),
+                ValueError, "You must provide one between hosts and scheme or cloud_id"
             ):
                 ShipperFactory.create(output="elasticsearch", hosts=[])
+
+        with self.subTest("create elasticsearch shipper empty cloud_id and no hosts"):
+            with self.assertRaisesRegex(
+                ValueError, "You must provide one between hosts and scheme or cloud_id"
+            ):
+                ShipperFactory.create(output="elasticsearch", cloud_id="")
+
+        with self.subTest("create elasticsearch shipper empty username and no api_key"):
+            with self.assertRaisesRegex(
+                ValueError, "You must provide one between username and password or api_key"
+            ):
+                ShipperFactory.create(output="elasticsearch", hosts=["hosts"], username="")
+
+        with self.subTest("create elasticsearch shipper empty api_key and no username"):
+            with self.assertRaisesRegex(
+                ValueError, "You must provide one between username and password or api_key"
+            ):
+                ShipperFactory.create(output="elasticsearch", hosts=["hosts"], api_key="")
+
 
         with self.subTest("create invalid type"):
             with self.assertRaisesRegex(

--- a/tests/shippers/test_factory.py
+++ b/tests/shippers/test_factory.py
@@ -25,7 +25,7 @@ class TestShipperFactory(TestCase):
             assert isinstance(shipper, ElasticsearchShipper)
 
         with self.subTest("create elasticsearch shipper success hosts and api key"):
-            shipper: CommonShipper = ShipperFactory.create(
+            shipper = ShipperFactory.create(
                 output="elasticsearch",
                 hosts=["hosts"],
                 scheme="scheme",
@@ -37,7 +37,7 @@ class TestShipperFactory(TestCase):
             assert isinstance(shipper, ElasticsearchShipper)
 
         with self.subTest("create elasticsearch shipper success cloud id and http auth"):
-            shipper: CommonShipper = ShipperFactory.create(
+            shipper = ShipperFactory.create(
                 output="elasticsearch",
                 cloud_id="cloud_id:bG9jYWxob3N0OjkyMDAkMA==",
                 username="username",
@@ -49,7 +49,7 @@ class TestShipperFactory(TestCase):
             assert isinstance(shipper, ElasticsearchShipper)
 
         with self.subTest("create elasticsearch shipper success cloud id and api key"):
-            shipper: CommonShipper = ShipperFactory.create(
+            shipper = ShipperFactory.create(
                 output="elasticsearch",
                 cloud_id="cloud_id:bG9jYWxob3N0OjkyMDAkMA==",
                 api_key="api_key",
@@ -59,35 +59,24 @@ class TestShipperFactory(TestCase):
 
             assert isinstance(shipper, ElasticsearchShipper)
         with self.subTest("create elasticsearch shipper no kwargs error"):
-            with self.assertRaisesRegex(
-                ValueError, "You must provide one between hosts and scheme or cloud_id"
-            ):
+            with self.assertRaisesRegex(ValueError, "You must provide one between hosts and scheme or cloud_id"):
                 ShipperFactory.create(output="elasticsearch")
 
         with self.subTest("create elasticsearch shipper empty hosts and no cloud_id"):
-            with self.assertRaisesRegex(
-                ValueError, "You must provide one between hosts and scheme or cloud_id"
-            ):
+            with self.assertRaisesRegex(ValueError, "You must provide one between hosts and scheme or cloud_id"):
                 ShipperFactory.create(output="elasticsearch", hosts=[])
 
         with self.subTest("create elasticsearch shipper empty cloud_id and no hosts"):
-            with self.assertRaisesRegex(
-                ValueError, "You must provide one between hosts and scheme or cloud_id"
-            ):
+            with self.assertRaisesRegex(ValueError, "You must provide one between hosts and scheme or cloud_id"):
                 ShipperFactory.create(output="elasticsearch", cloud_id="")
 
         with self.subTest("create elasticsearch shipper empty username and no api_key"):
-            with self.assertRaisesRegex(
-                ValueError, "You must provide one between username and password or api_key"
-            ):
+            with self.assertRaisesRegex(ValueError, "You must provide one between username and password or api_key"):
                 ShipperFactory.create(output="elasticsearch", hosts=["hosts"], username="")
 
         with self.subTest("create elasticsearch shipper empty api_key and no username"):
-            with self.assertRaisesRegex(
-                ValueError, "You must provide one between username and password or api_key"
-            ):
+            with self.assertRaisesRegex(ValueError, "You must provide one between username and password or api_key"):
                 ShipperFactory.create(output="elasticsearch", hosts=["hosts"], api_key="")
-
 
         with self.subTest("create invalid type"):
             with self.assertRaisesRegex(

--- a/tests/shippers/test_factory.py
+++ b/tests/shippers/test_factory.py
@@ -11,11 +11,10 @@ from shippers import CommonShipper, ElasticsearchShipper, ShipperFactory
 
 class TestShipperFactory(TestCase):
     def test_create(self) -> None:
-        with self.subTest("create elasticsearch shipper success hosts and http auth"):
+        with self.subTest("create elasticsearch shipper success elasticsearch_url and http auth"):
             shipper: CommonShipper = ShipperFactory.create(
                 output="elasticsearch",
-                hosts=["hosts"],
-                scheme="scheme",
+                elasticsearch_url="elasticsearch_url",
                 username="username",
                 password="password",
                 dataset="dataset",
@@ -24,11 +23,10 @@ class TestShipperFactory(TestCase):
 
             assert isinstance(shipper, ElasticsearchShipper)
 
-        with self.subTest("create elasticsearch shipper success hosts and api key"):
+        with self.subTest("create elasticsearch shipper success elasticsearch_url and api key"):
             shipper = ShipperFactory.create(
                 output="elasticsearch",
-                hosts=["hosts"],
-                scheme="scheme",
+                elasticsearch_url="elasticsearch_url",
                 api_key="api_key",
                 dataset="dataset",
                 namespace="namespace",
@@ -59,24 +57,24 @@ class TestShipperFactory(TestCase):
 
             assert isinstance(shipper, ElasticsearchShipper)
         with self.subTest("create elasticsearch shipper no kwargs error"):
-            with self.assertRaisesRegex(ValueError, "You must provide one between hosts and scheme or cloud_id"):
+            with self.assertRaisesRegex(ValueError, "You must provide one between elasticsearch_url or cloud_id"):
                 ShipperFactory.create(output="elasticsearch")
 
-        with self.subTest("create elasticsearch shipper empty hosts and no cloud_id"):
-            with self.assertRaisesRegex(ValueError, "You must provide one between hosts and scheme or cloud_id"):
-                ShipperFactory.create(output="elasticsearch", hosts=[])
+        with self.subTest("create elasticsearch shipper empty elasticsearch_url and no cloud_id"):
+            with self.assertRaisesRegex(ValueError, "You must provide one between elasticsearch_url or cloud_id"):
+                ShipperFactory.create(output="elasticsearch", elasticsearch_url="")
 
-        with self.subTest("create elasticsearch shipper empty cloud_id and no hosts"):
-            with self.assertRaisesRegex(ValueError, "You must provide one between hosts and scheme or cloud_id"):
+        with self.subTest("create elasticsearch shipper empty cloud_id and no elasticsearch_url"):
+            with self.assertRaisesRegex(ValueError, "You must provide one between elasticsearch_url or cloud_id"):
                 ShipperFactory.create(output="elasticsearch", cloud_id="")
 
         with self.subTest("create elasticsearch shipper empty username and no api_key"):
             with self.assertRaisesRegex(ValueError, "You must provide one between username and password or api_key"):
-                ShipperFactory.create(output="elasticsearch", hosts=["hosts"], username="")
+                ShipperFactory.create(output="elasticsearch", elasticsearch_url="elasticsearch_url", username="")
 
         with self.subTest("create elasticsearch shipper empty api_key and no username"):
             with self.assertRaisesRegex(ValueError, "You must provide one between username and password or api_key"):
-                ShipperFactory.create(output="elasticsearch", hosts=["hosts"], api_key="")
+                ShipperFactory.create(output="elasticsearch", elasticsearch_url="elasticsearch_url", api_key="")
 
         with self.subTest("create invalid type"):
             with self.assertRaisesRegex(
@@ -88,8 +86,7 @@ class TestShipperFactory(TestCase):
         elasticsearch_output = ElasticSearchOutput(
             output_type="elasticsearch",
             kwargs={
-                "hosts": ["hosts"],
-                "scheme": "scheme",
+                "elasticsearch_url": "elasticsearch_url",
                 "username": "username",
                 "password": "password",
                 "dataset": "dataset",

--- a/tests/storage/test_s3.py
+++ b/tests/storage/test_s3.py
@@ -76,7 +76,7 @@ class MockContent:
             assert MockContent.f_stream_gzip is not None
             MockContent.f_stream_gzip.seek(range_int)
             content_body = MockContent.f_stream_gzip
-            content_length = len(MockContent.f_content_gzip[range_int:])
+            content_length = MockContent.f_size_gzip
 
         return {"Body": StreamingBody(content_body, content_length), "ContentLength": content_length}
 


### PR DESCRIPTION
New features:
- option to use CloudID instead of hosts/scheme in config in order to connect to Elasticsearch
- option to use Base64 encoded api key instead of username/password in config in order to authenticate to Elasticsearch