### PR TITLE
fix elasticsearch_url over cloud_id precedence

### DIFF
--- a/share/config.py
+++ b/share/config.py
@@ -80,8 +80,8 @@ class ElasticSearchOutput(Output):
             raise ValueError("Elasticsearch Output elasticsearch_url or cloud_id must be set")
 
         if self.cloud_id and self.elasticsearch_url:
-            shared_logger.warn("both elasticsearch_url and cloud_id set in config: using cloud_id")
-            self.elasticsearch_url = ""
+            shared_logger.warn("both elasticsearch_url and cloud_id set in config: using elasticsearch_url")
+            self.cloud_id = ""
 
         if not self.username and not self.api_key:
             raise ValueError("Elasticsearch Output username and password or api_key must be set")

--- a/tests/share/test_config.py
+++ b/tests/share/test_config.py
@@ -204,16 +204,16 @@ class TestElasticSearchOutput(TestCase):
             )
 
             assert elasticsearch.type == "elasticsearch"
-            assert elasticsearch.cloud_id == "cloud_id"
+            assert elasticsearch.elasticsearch_url == "elasticsearch_url"
             assert elasticsearch.api_key == "api_key"
-            assert not elasticsearch.elasticsearch_url
+            assert not elasticsearch.cloud_id
             assert not elasticsearch.username
             assert not elasticsearch.password
             assert elasticsearch.dataset == "dataset"
             assert elasticsearch.namespace == "namespace"
             assert elasticsearch.kwargs == {
+                "elasticsearch_url": "elasticsearch_url",
                 "api_key": "api_key",
-                "cloud_id": "cloud_id",
                 "dataset": "dataset",
                 "namespace": "namespace",
             }


### PR DESCRIPTION
`elasticsearch_url` have precedence over `cloud_id`, not the contrary