### PR TITLE
Fix handling of different event sources

### DIFF
--- a/.internal/aws/cloudformation/template.yaml
+++ b/.internal/aws/cloudformation/template.yaml
@@ -53,7 +53,7 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt ElasticServerlessForwarderContinuingQueue.Arn
-            BatchSize: 1
+            BatchSize: 10
             Enabled: true
 Metadata:
   AWS::ServerlessRepo::Application:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v0.26.0 - 2022/03/15
+##### Features
+* Support handling of continuing queue with batch size greater than 1: [#95](https://github.com/elastic/elastic-serverless-forwarder/pull/95)
+
 ### v0.24.0 - 2022/03/15
 ##### Features
 * Add support for CloudWatch Logs subscription filter input: [#94](https://github.com/elastic/elastic-serverless-forwarder/pull/94)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### v0.26.0 - 2022/03/15
+### v0.25.0 - 2022/03/15
 ##### Features
 * Support handling of continuing queue with batch size greater than 1: [#95](https://github.com/elastic/elastic-serverless-forwarder/pull/95)
 

--- a/docs/README-AWS.md
+++ b/docs/README-AWS.md
@@ -369,7 +369,7 @@ Resources:
 
     * Adding an Event Source Mapping when using the SQS replay queue
       ```json
-      "ESFREplayQueueEventSource": {
+      "ESFReplayQueueEventSource": {
         "Type": "AWS::Lambda::EventSourceMapping",
         "Properties": {
           "Enabled": true,

--- a/handlers/aws/__init__.py
+++ b/handlers/aws/__init__.py
@@ -3,4 +3,4 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 
 from .handler import lambda_handler
-from .utils import ConfigFileException, TriggerTypeException, get_sqs_client
+from .utils import ConfigFileException, TriggerTypeException

--- a/handlers/aws/handler.py
+++ b/handlers/aws/handler.py
@@ -4,11 +4,11 @@
 
 import json
 import os
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from aws_lambda_typing import context as context_
 
-from share import Config, parse_config, shared_logger
+from share import parse_config, shared_logger
 from share.secretsmanager import aws_sm_expander
 
 from .cloudwatch_logs_trigger import (
@@ -30,7 +30,8 @@ from .utils import (
     config_yaml_from_s3,
     delete_sqs_record,
     get_log_group_arn_and_region_from_log_group_name,
-    get_shipper_and_input,
+    get_shipper_from_input,
+    get_sqs_client,
     get_trigger_type_and_config_source,
     is_continuing_of_cloudwatch_logs,
     wrap_try_except,
@@ -58,18 +59,9 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
     except Exception as e:
         raise TriggerTypeException(e)
 
-    trigger_event_source_arn: str = ""
-    if "Records" in lambda_event:
-        trigger_event_source_arn = lambda_event["Records"][0]["eventSourceARN"]
-
-    config_yaml: str = ""
     try:
         if config_source == CONFIG_FROM_PAYLOAD:
             config_yaml = config_yaml_from_payload(lambda_event)
-
-            payload = lambda_event["Records"][0]["messageAttributes"]
-            if "originalEventSource" in payload:
-                lambda_event["Records"][0]["eventSourceARN"] = payload["originalEventSource"]["stringValue"]
         elif config_source == CONFIG_FROM_S3FILE:
             config_yaml = config_yaml_from_s3()
         else:
@@ -80,7 +72,6 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
     if config_yaml == "":
         raise ConfigFileException("empty config")
 
-    config: Optional[Config] = None
     try:
         shared_logger.debug("config", extra={"yaml": config_yaml})
         config = parse_config(config_yaml, _expanders)
@@ -88,6 +79,8 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
         raise ConfigFileException(e)
 
     assert config is not None
+
+    sqs_client = get_sqs_client()
 
     if trigger_type == "replay-sqs":
         for replay_record in lambda_event["Records"]:
@@ -109,30 +102,26 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
 
     sent_event: int = 0
 
-    aws_region = ""
-    cloudwatch_logs_event = {}
     if trigger_type == "cloudwatch-logs":
         cloudwatch_logs_event = _from_awslogs_data_to_event(lambda_event["event"]["awslogs"]["data"])
         log_group_arn, aws_region = get_log_group_arn_and_region_from_log_group_name(cloudwatch_logs_event["logGroup"])
         input_id = log_group_arn
-    else:
-        input_id = lambda_event["Records"][0]["eventSourceARN"]
 
-    trigger_type_for_shipper_and_input = trigger_type
-    is_continuation_of_cloudwatch_logs = is_continuing_of_cloudwatch_logs(lambda_event)
-    if is_continuation_of_cloudwatch_logs:
-        trigger_type_for_shipper_and_input = "cloudwatch-logs"
-
-    composite_shipper, event_input = get_shipper_and_input(
-        config, config_yaml, trigger_type_for_shipper_and_input, lambda_event, input_id
-    )
-
-    if trigger_type == "cloudwatch-logs":
         if "logGroup" not in cloudwatch_logs_event:
             raise ValueError("logGroup key not present in the cloudwatch logs payload")
 
         if "logStream" not in cloudwatch_logs_event:
             raise ValueError("logStream key not present in the cloudwatch logs payload")
+
+        event_input = config.get_input_by_type_and_id(trigger_type, input_id)
+        if not event_input:
+            shared_logger.warning("no input defined", extra={"input_type": trigger_type, "input_id": input_id})
+
+            return "completed"
+
+        composite_shipper = get_shipper_from_input(
+            event_input=event_input, lambda_event=lambda_event, at_record=0, config_yaml=config_yaml
+        )
 
         for es_event, last_ending_offset, current_log_event_n in _handle_cloudwatch_logs_event(
             cloudwatch_logs_event, aws_region
@@ -153,11 +142,12 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
                 composite_shipper.flush()
 
                 _handle_cloudwatch_logs_continuation(
+                    sqs_client=sqs_client,
                     sqs_continuing_queue=sqs_continuing_queue,
                     last_ending_offset=last_ending_offset,
                     cloudwatch_logs_event=cloudwatch_logs_event,
                     current_log_event=current_log_event_n,
-                    event_input_id=event_input.id,
+                    event_input_id=input_id,
                     config_yaml=config_yaml,
                 )
 
@@ -169,6 +159,17 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
     if trigger_type == "kinesis-data-stream":
         all_sequence_numbers: dict[str, str] = {}
         ret: dict[Any, list[dict[str, str]]] = {"batchItemFailures": []}
+
+        input_id = lambda_event["Records"][0]["eventSourceARN"]
+        event_input = config.get_input_by_type_and_id(trigger_type, input_id)
+        if not event_input:
+            shared_logger.warning("no input defined", extra={"input_type": trigger_type, "input_id": input_id})
+
+            return "completed"
+
+        composite_shipper = get_shipper_from_input(
+            event_input=event_input, lambda_event=lambda_event, at_record=0, config_yaml=config_yaml
+        )
 
         for kinesis_record in lambda_event["Records"]:
             all_sequence_numbers[kinesis_record["kinesis"]["sequenceNumber"]] = kinesis_record["kinesis"][
@@ -202,87 +203,130 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
 
             return ret
 
-    if trigger_type == "sqs":
-        previous_sqs_record = 0
-        for es_event, last_ending_offset, current_sqs_record in _handle_sqs_event(
-            config, lambda_event, is_continuation_of_cloudwatch_logs
-        ):
-            shared_logger.debug("es_event", extra={"es_event": es_event})
+    if trigger_type == "s3-sqs" or trigger_type == "sqs":
 
-            composite_shipper.send(es_event)
-            sent_event += 1
+        def event_processing_callback(
+            processing_es_event: dict[str, Any], processing_sent_event: int
+        ) -> tuple[bool, int]:
+            shared_logger.debug("es_event", extra={"es_event": processing_es_event})
 
-            if current_sqs_record > previous_sqs_record:
-                sqs_record = lambda_event["Records"][previous_sqs_record]
-                delete_sqs_record(trigger_event_source_arn, sqs_record["receiptHandle"])
-
-            previous_sqs_record = current_sqs_record
+            composite_shipper.send(processing_es_event)
+            processing_sent_event += 1
 
             if lambda_context is not None and lambda_context.get_remaining_time_in_millis() < _completion_grace_period:
-                sqs_continuing_queue = os.environ["SQS_CONTINUE_URL"]
-
-                shared_logger.info(
-                    "lambda is going to shutdown, continuing on dedicated sqs queue",
-                    extra={"sqs_queue": sqs_continuing_queue, "sent_event": sent_event},
-                )
-
                 composite_shipper.flush()
 
-                _handle_sqs_continuation(
-                    trigger_event_source_arn=trigger_event_source_arn,
-                    sqs_continuing_queue=sqs_continuing_queue,
-                    last_ending_offset=last_ending_offset,
-                    lambda_event=lambda_event,
-                    event_input_id=event_input.id,
-                    current_sqs_record=current_sqs_record,
-                    config_yaml=config_yaml,
-                )
+                return True, processing_sent_event
 
-                return "continuing"
+            return False, processing_sent_event
 
-        composite_shipper.flush()
-        shared_logger.info("lambda processed all the events", extra={"sent_event": sent_event})
+        def handle_timeout(
+            remaining_sqs_records: list[dict[str, Any]],
+            timeout_input_type: str,
+            timeout_input_id: str,
+            timeout_last_ending_offset: int,
+            timeout_sent_event: int,
+            timeout_config_yaml: str,
+            timeout_current_s3_record: int = 0,
+        ) -> None:
+            timeout_sqs_continuing_queue = os.environ["SQS_CONTINUE_URL"]
 
-    if trigger_type == "s3-sqs":
+            shared_logger.info(
+                "lambda is going to shutdown, continuing on dedicated sqs queue",
+                extra={"sqs_queue": timeout_sqs_continuing_queue, "sent_event": timeout_sent_event},
+            )
+
+            for timeout_sqs_record in remaining_sqs_records:
+                if timeout_input_type == "s3-sqs":
+                    _handle_s3_sqs_continuation(
+                        sqs_client=sqs_client,
+                        sqs_continuing_queue=timeout_sqs_continuing_queue,
+                        last_ending_offset=timeout_last_ending_offset,
+                        sqs_record=timeout_sqs_record,
+                        current_s3_record=timeout_current_s3_record,
+                        event_input_id=timeout_input_id,
+                        config_yaml=timeout_config_yaml,
+                    )
+                elif timeout_input_type == "sqs" or timeout_input_type == "cloudwatch-logs":
+                    _handle_sqs_continuation(
+                        sqs_client=sqs_client,
+                        sqs_continuing_queue=timeout_sqs_continuing_queue,
+                        last_ending_offset=timeout_last_ending_offset,
+                        sqs_record=timeout_sqs_record,
+                        event_input_id=timeout_input_id,
+                        config_yaml=timeout_config_yaml,
+                    )
+
+                delete_sqs_record(sqs_record["eventSourceARN"], sqs_record["receiptHandle"])
+
         previous_sqs_record = 0
-        for es_event, last_ending_offset, current_sqs_record, current_s3_record in _handle_s3_sqs_event(
-            config, lambda_event
-        ):
-            shared_logger.debug("es_event", extra={"es_event": es_event})
-
-            composite_shipper.send(es_event)
-            sent_event += 1
-
+        for current_sqs_record, sqs_record in enumerate(lambda_event["Records"]):
             if current_sqs_record > previous_sqs_record:
-                sqs_record = lambda_event["Records"][previous_sqs_record]
-                delete_sqs_record(trigger_event_source_arn, sqs_record["receiptHandle"])
+                deleting_sqs_record = lambda_event["Records"][previous_sqs_record]
+                delete_sqs_record(deleting_sqs_record["eventSourceARN"], deleting_sqs_record["receiptHandle"])
 
-            previous_sqs_record = current_sqs_record
+                previous_sqs_record = current_sqs_record
 
-            if lambda_context is not None and lambda_context.get_remaining_time_in_millis() < _completion_grace_period:
-                sqs_continuing_queue = os.environ["SQS_CONTINUE_URL"]
+            is_continuation_of_cloudwatch_logs = is_continuing_of_cloudwatch_logs(sqs_record)
 
-                shared_logger.info(
-                    "lambda is going to shutdown, continuing on dedicated sqs queue",
-                    extra={"sqs_queue": sqs_continuing_queue, "sent_event": sent_event},
-                )
+            if is_continuation_of_cloudwatch_logs:
+                input_type = "cloudwatch-logs"
+            else:
+                input_type, _ = get_trigger_type_and_config_source(lambda_event, current_sqs_record)
 
-                composite_shipper.flush()
+            input_id = sqs_record["eventSourceARN"]
+            if "messageAttributes" in sqs_record and "originalEventSourceARN" in sqs_record["messageAttributes"]:
+                input_id = sqs_record["messageAttributes"]["originalEventSourceARN"]["stringValue"]
 
-                _handle_s3_sqs_continuation(
-                    trigger_event_source_arn=trigger_event_source_arn,
-                    sqs_continuing_queue=sqs_continuing_queue,
-                    lambda_event=lambda_event,
-                    event_input_id=event_input.id,
-                    last_ending_offset=last_ending_offset,
-                    current_sqs_record=current_sqs_record,
-                    current_s3_record=current_s3_record,
-                    config_yaml=config_yaml,
-                )
+            event_input = config.get_input_by_type_and_id(input_type, input_id)
+            if not event_input:
+                shared_logger.warning("no input defined", extra={"input_type": input_type, "input_id": input_id})
+                continue
 
-                return "continuing"
+            composite_shipper = get_shipper_from_input(
+                event_input=event_input,
+                lambda_event=lambda_event,
+                at_record=current_sqs_record,
+                config_yaml=config_yaml,
+            )
 
-        composite_shipper.flush()
+            if input_type == "sqs" or input_type == "cloudwatch-logs":
+                for es_event, last_ending_offset in _handle_sqs_event(
+                    sqs_record, is_continuation_of_cloudwatch_logs, input_id
+                ):
+                    timeout, sent_event = event_processing_callback(
+                        processing_es_event=es_event, processing_sent_event=sent_event
+                    )
+                    if timeout:
+                        handle_timeout(
+                            remaining_sqs_records=lambda_event["Records"][current_sqs_record:],
+                            timeout_input_type=input_type,
+                            timeout_input_id=input_id,
+                            timeout_last_ending_offset=last_ending_offset,
+                            timeout_sent_event=sent_event,
+                            timeout_config_yaml=config_yaml,
+                        )
+                        return "continuing"
+
+            elif input_type == "s3-sqs":
+                for es_event, last_ending_offset, current_s3_record in _handle_s3_sqs_event(sqs_record):
+                    timeout, sent_event = event_processing_callback(
+                        processing_es_event=es_event, processing_sent_event=sent_event
+                    )
+                    if timeout:
+                        handle_timeout(
+                            remaining_sqs_records=lambda_event["Records"][current_sqs_record:],
+                            timeout_input_type=input_type,
+                            timeout_input_id=input_id,
+                            timeout_last_ending_offset=last_ending_offset,
+                            timeout_sent_event=sent_event,
+                            timeout_config_yaml=config_yaml,
+                            timeout_current_s3_record=current_s3_record,
+                        )
+                        return "continuing"
+
+            composite_shipper.flush()
+
         shared_logger.info("lambda processed all the events", extra={"sent_event": sent_event})
 
     return "completed"

--- a/handlers/aws/handler.py
+++ b/handlers/aws/handler.py
@@ -207,7 +207,7 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
     if trigger_type == "s3-sqs" or trigger_type == "sqs":
         composite_shipper_cache: dict[str, CompositeShipper] = {}
 
-        def event_processing_callback(
+        def event_processing(
             processing_composing_shipper: CompositeShipper,
             processing_es_event: dict[str, Any],
             processing_sent_event: int,
@@ -301,7 +301,7 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
                 for es_event, last_ending_offset in _handle_sqs_event(
                     sqs_record, is_continuation_of_cloudwatch_logs, input_id
                 ):
-                    timeout, sent_event = event_processing_callback(
+                    timeout, sent_event = event_processing(
                         processing_composing_shipper=composite_shipper,
                         processing_es_event=es_event,
                         processing_sent_event=sent_event,
@@ -323,7 +323,7 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
 
             elif input_type == "s3-sqs":
                 for es_event, last_ending_offset, current_s3_record in _handle_s3_sqs_event(sqs_record):
-                    timeout, sent_event = event_processing_callback(
+                    timeout, sent_event = event_processing(
                         processing_composing_shipper=composite_shipper,
                         processing_es_event=es_event,
                         processing_sent_event=sent_event,

--- a/handlers/aws/s3_sqs_trigger.py
+++ b/handlers/aws/s3_sqs_trigger.py
@@ -9,135 +9,120 @@ from typing import Any, Iterator
 from urllib.parse import unquote_plus
 
 import elasticapm
+from botocore.client import BaseClient as BotoBaseClient
 
-from share import Config, shared_logger
+from share import shared_logger
 from storage import CommonStorage, StorageFactory
 
 from .event import _default_event
-from .utils import delete_sqs_record, get_bucket_name_from_arn, get_sqs_client
+from .utils import get_bucket_name_from_arn
 
 
 def _handle_s3_sqs_continuation(
-    trigger_event_source_arn: str,
+    sqs_client: BotoBaseClient,
     sqs_continuing_queue: str,
-    lambda_event: dict[str, Any],
-    event_input_id: str,
     last_ending_offset: int,
-    current_sqs_record: int,
+    sqs_record: dict[str, Any],
     current_s3_record: int,
+    event_input_id: str,
     config_yaml: str,
 ) -> None:
     """
-    Handler of the continuation queue for sqs inputs
+    Handler of the continuation queue for s3-sqs inputs
     If a sqs message cannot be fully processed before the
     timeout of the lambda this handler will be called: it will
     send new sqs messages for the unprocessed records to the
     internal continuing sqs queue
     """
 
-    sqs_records = lambda_event["Records"][current_sqs_record:]
-    body = json.loads(sqs_records[0]["body"])
+    body = json.loads(sqs_record["body"])
     body["Records"] = body["Records"][current_s3_record:]
     body["Records"][0]["last_ending_offset"] = last_ending_offset
-    sqs_records[0]["body"] = json.dumps(body)
+    sqs_record["body"] = json.dumps(body)
 
-    sqs_client = get_sqs_client()
+    sqs_client.send_message(
+        QueueUrl=sqs_continuing_queue,
+        MessageBody=sqs_record["body"],
+        MessageAttributes={
+            "config": {"StringValue": config_yaml, "DataType": "String"},
+            "originalEventSourceARN": {"StringValue": event_input_id, "DataType": "String"},
+        },
+    )
 
-    for sqs_record in sqs_records:
-        sqs_client.send_message(
-            QueueUrl=sqs_continuing_queue,
-            MessageBody=sqs_record["body"],
-            MessageAttributes={
-                "config": {"StringValue": config_yaml, "DataType": "String"},
-                "originalEventSource": {"StringValue": event_input_id, "DataType": "String"},
+    shared_logger.debug("continuing", extra={"sqs_continuing_queue": sqs_continuing_queue, "body": sqs_record["body"]})
+
+
+def _handle_s3_sqs_event(sqs_record: dict[str, Any]) -> Iterator[tuple[dict[str, Any], int, int]]:
+    """
+    Handler for s3-sqs input.
+    It takes an sqs record in the sqs trigger and process
+    corresponding object in S3 buckets sending to the defined outputs.
+    """
+    body = json.loads(sqs_record["body"])
+    for s3_record_n, s3_record in enumerate(body["Records"]):
+        aws_region = s3_record["awsRegion"]
+        bucket_arn = unquote_plus(s3_record["s3"]["bucket"]["arn"], "utf-8")
+        object_key = unquote_plus(s3_record["s3"]["object"]["key"], "utf-8")
+        last_ending_offset = s3_record["last_ending_offset"] if "last_ending_offset" in s3_record else 0
+
+        if len(bucket_arn) == 0 or len(object_key) == 0:
+            raise Exception("Cannot find bucket_arn or object_key for s3")
+
+        bucket_name: str = get_bucket_name_from_arn(bucket_arn)
+        storage: CommonStorage = StorageFactory.create(
+            storage_type="s3", bucket_name=bucket_name, object_key=object_key
+        )
+
+        shared_logger.info(
+            "sqs event",
+            extra={
+                "range_start": last_ending_offset,
+                "bucket_arn": bucket_arn,
+                "object_key": object_key,
             },
         )
 
-        delete_sqs_record(trigger_event_source_arn, sqs_record["receiptHandle"])
-
-        shared_logger.debug(
-            "continuing", extra={"sqs_continuing_queue": sqs_continuing_queue, "body": sqs_record["body"]}
+        span = elasticapm.capture_span(f"WAIT FOR OFFSET STARTING AT {last_ending_offset}")
+        span.__enter__()
+        events = storage.get_by_lines(
+            range_start=last_ending_offset,
         )
+        for log_event, ending_offset, newline_length in events:
+            assert isinstance(log_event, bytes)
 
-
-def _handle_s3_sqs_event(config: Config, event: dict[str, Any]) -> Iterator[tuple[dict[str, Any], int, int, int]]:
-    """
-    Handler for sqs inputs.
-    It iterates through sqs records in the sqs trigger and process
-    corresponding object in S3 buckets sending to the defined outputs.
-    If a sqs message cannot be fully processed before the
-    timeout of the lambda it will call the sqs continuing handler
-    """
-    for sqs_record_n, sqs_record in enumerate(event["Records"]):
-        event_input = config.get_input_by_type_and_id("s3-sqs", sqs_record["eventSourceARN"])
-        if not event_input:
-            return None
-
-        body = json.loads(sqs_record["body"])
-        for s3_record_n, s3_record in enumerate(body["Records"]):
-            aws_region = s3_record["awsRegion"]
-            bucket_arn = unquote_plus(s3_record["s3"]["bucket"]["arn"], "utf-8")
-            object_key = unquote_plus(s3_record["s3"]["object"]["key"], "utf-8")
-            last_ending_offset = s3_record["last_ending_offset"] if "last_ending_offset" in s3_record else 0
-
-            if len(bucket_arn) == 0 or len(object_key) == 0:
-                raise Exception("Cannot find bucket_arn or object_key for s3")
-
-            bucket_name: str = get_bucket_name_from_arn(bucket_arn)
-            storage: CommonStorage = StorageFactory.create(
-                storage_type="s3", bucket_name=bucket_name, object_key=object_key
-            )
-
-            shared_logger.info(
-                "sqs event",
-                extra={
-                    "range_start": last_ending_offset,
-                    "bucket_arn": bucket_arn,
-                    "object_key": object_key,
-                },
-            )
-
-            span = elasticapm.capture_span(f"WAIT FOR OFFSET STARTING AT {last_ending_offset}")
-            span.__enter__()
-            events = storage.get_by_lines(
-                range_start=last_ending_offset,
-            )
-            for log_event, ending_offset, newline_length in events:
-                assert isinstance(log_event, bytes)
-
-                # let's be sure that on the first yield `ending_offset`
-                # doesn't overlap `last_ending_offset`: in case we
-                # skip in order to not ingest twice the same event
-                if ending_offset < last_ending_offset:
-                    shared_logger.warning(
-                        "skipping event",
-                        extra={
-                            "ending_offset": ending_offset,
-                            "last_ending_offset": last_ending_offset,
-                        },
-                    )
-                    continue
-
-                if span:
-                    span.__exit__(None, None, None)
-                    span = None
-
-                es_event = deepcopy(_default_event)
-                es_event["@timestamp"] = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-                es_event["fields"]["message"] = log_event.decode("UTF-8")
-                es_event["fields"]["log"]["offset"] = ending_offset - (len(log_event) + newline_length)
-
-                es_event["fields"]["log"]["file"]["path"] = "https://{0}.s3.{1}.amazonaws.com/{2}".format(
-                    bucket_name, aws_region, object_key
+            # let's be sure that on the first yield `ending_offset`
+            # doesn't overlap `last_ending_offset`: in case we
+            # skip in order to not ingest twice the same event
+            if ending_offset < last_ending_offset:
+                shared_logger.warning(
+                    "skipping event",
+                    extra={
+                        "ending_offset": ending_offset,
+                        "last_ending_offset": last_ending_offset,
+                    },
                 )
+                continue
 
-                es_event["fields"]["aws"] = {
-                    "s3": {
-                        "bucket": {"name": bucket_name, "arn": bucket_arn},
-                        "object": {"key": object_key},
-                    }
+            if span:
+                span.__exit__(None, None, None)
+                span = None
+
+            es_event = deepcopy(_default_event)
+            es_event["@timestamp"] = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            es_event["fields"]["message"] = log_event.decode("UTF-8")
+            es_event["fields"]["log"]["offset"] = ending_offset - (len(log_event) + newline_length)
+
+            es_event["fields"]["log"]["file"]["path"] = "https://{0}.s3.{1}.amazonaws.com/{2}".format(
+                bucket_name, aws_region, object_key
+            )
+
+            es_event["fields"]["aws"] = {
+                "s3": {
+                    "bucket": {"name": bucket_name, "arn": bucket_arn},
+                    "object": {"key": object_key},
                 }
+            }
 
-                es_event["fields"]["cloud"]["region"] = aws_region
+            es_event["fields"]["cloud"]["region"] = aws_region
 
-                yield es_event, ending_offset, sqs_record_n, s3_record_n
+            yield es_event, ending_offset, s3_record_n

--- a/handlers/aws/sqs_trigger.py
+++ b/handlers/aws/sqs_trigger.py
@@ -6,20 +6,21 @@ import datetime
 from copy import deepcopy
 from typing import Any, Iterator
 
-from share import Config, shared_logger
+from botocore.client import BaseClient as BotoBaseClient
+
+from share import shared_logger
 from storage import CommonStorage, StorageFactory
 
 from .event import _default_event
-from .utils import delete_sqs_record, get_queue_url_from_sqs_arn, get_sqs_client, get_sqs_queue_name_and_region_from_arn
+from .utils import get_queue_url_from_sqs_arn, get_sqs_queue_name_and_region_from_arn
 
 
 def _handle_sqs_continuation(
-    trigger_event_source_arn: str,
+    sqs_client: BotoBaseClient,
     sqs_continuing_queue: str,
     last_ending_offset: int,
-    lambda_event: dict[str, Any],
+    sqs_record: dict[str, Any],
     event_input_id: str,
-    current_sqs_record: int,
     config_yaml: str,
 ) -> None:
     """
@@ -30,116 +31,99 @@ def _handle_sqs_continuation(
     internal continuing sqs queue
     """
 
-    sqs_records = lambda_event["Records"][current_sqs_record:]
+    sqs_client.send_message(
+        QueueUrl=sqs_continuing_queue,
+        MessageBody=sqs_record["body"],
+        MessageAttributes={
+            "config": {"StringValue": config_yaml, "DataType": "String"},
+            "originalMessageId": {"StringValue": sqs_record["messageId"], "DataType": "String"},
+            "originalEventSourceARN": {"StringValue": event_input_id, "DataType": "String"},
+            "originalLastEndingOffset": {"StringValue": str(last_ending_offset), "DataType": "Number"},
+        },
+    )
 
-    sqs_client = get_sqs_client()
-
-    for sqs_record in sqs_records:
-        sqs_client.send_message(
-            QueueUrl=sqs_continuing_queue,
-            MessageBody=sqs_record["body"],
-            MessageAttributes={
-                "config": {"StringValue": config_yaml, "DataType": "String"},
-                "originalMessageId": {"StringValue": sqs_record["messageId"], "DataType": "String"},
-                "originalEventSource": {"StringValue": event_input_id, "DataType": "String"},
-                "originalLastEndingOffset": {"StringValue": str(last_ending_offset), "DataType": "Number"},
-            },
-        )
-
-        delete_sqs_record(trigger_event_source_arn, sqs_record["receiptHandle"])
-
-        shared_logger.debug(
-            "continuing",
-            extra={
-                "sqs_continuing_queue": sqs_continuing_queue,
-                "body": sqs_record["body"],
-                "last_ending_offset": last_ending_offset,
-                "message_id": sqs_record["messageId"],
-            },
-        )
+    shared_logger.debug(
+        "continuing",
+        extra={
+            "sqs_continuing_queue": sqs_continuing_queue,
+            "body": sqs_record["body"],
+            "last_ending_offset": last_ending_offset,
+            "message_id": sqs_record["messageId"],
+        },
+    )
 
 
 def _handle_sqs_event(
-    config: Config, event: dict[str, Any], is_continuation_of_cloudwatch_logs: bool
-) -> Iterator[tuple[dict[str, Any], int, int]]:
+    sqs_record: dict[str, Any], is_continuation_of_cloudwatch_logs: bool, input_id: str
+) -> Iterator[tuple[dict[str, Any], int]]:
     """
     Handler for sqs inputs.
     It iterates through sqs records in the sqs trigger and process
     content of body payload in the record.
-    If a sqs message cannot be fully processed before the
-    timeout of the lambda it will call the sqs continuing handler
     """
 
-    for sqs_record_n, sqs_record in enumerate(event["Records"]):
-        input_type = "sqs"
+    queue_name, aws_region = get_sqs_queue_name_and_region_from_arn(input_id)
+    storage: CommonStorage = StorageFactory.create(storage_type="payload", payload=sqs_record["body"])
+
+    range_start = 0
+
+    payload: dict[str, Any] = {}
+    if "messageAttributes" in sqs_record:
+        payload = sqs_record["messageAttributes"]
+
+    if "originalLastEndingOffset" in payload:
+        range_start = int(payload["originalLastEndingOffset"]["stringValue"])
+
+    events = storage.get_by_lines(
+        range_start=range_start,
+    )
+
+    for log_event, ending_offset, newline_length in events:
+        assert isinstance(log_event, bytes)
+
+        es_event = deepcopy(_default_event)
+        es_event["@timestamp"] = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        es_event["fields"]["message"] = log_event.decode("UTF-8")
+        es_event["fields"]["log"]["offset"] = ending_offset - (len(log_event) + newline_length)
+
         if is_continuation_of_cloudwatch_logs:
-            input_type = "cloudwatch-logs"
-        event_input = config.get_input_by_type_and_id(input_type, sqs_record["eventSourceARN"])
-        if not event_input:
-            return None
+            event_id = ""
+            log_group_name = ""
+            log_stream_name = ""
 
-        queue_name, aws_region = get_sqs_queue_name_and_region_from_arn(sqs_record["eventSourceARN"])
-        storage: CommonStorage = StorageFactory.create(storage_type="payload", payload=sqs_record["body"])
+            if "originalEventId" in payload:
+                event_id = payload["originalEventId"]["stringValue"]
 
-        range_start = 0
+            if "originalLogGroup" in payload:
+                log_group_name = payload["originalLogGroup"]["stringValue"]
 
-        payload: dict[str, Any] = {}
-        if "messageAttributes" in sqs_record:
-            payload = sqs_record["messageAttributes"]
+            if "originalLogStream" in payload:
+                log_stream_name = payload["originalLogStream"]["stringValue"]
 
-        if "originalLastEndingOffset" in payload:
-            range_start = int(payload["originalLastEndingOffset"]["stringValue"])
+            es_event["fields"]["log"]["file"]["path"] = f"{log_group_name}/{log_stream_name}"
 
-        events = storage.get_by_lines(
-            range_start=range_start,
-        )
-
-        for log_event, ending_offset, newline_length in events:
-            assert isinstance(log_event, bytes)
-
-            es_event = deepcopy(_default_event)
-            es_event["@timestamp"] = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-            es_event["fields"]["message"] = log_event.decode("UTF-8")
-            es_event["fields"]["log"]["offset"] = ending_offset - (len(log_event) + newline_length)
-
-            if is_continuation_of_cloudwatch_logs:
-                event_id = ""
-                log_group_name = ""
-                log_stream_name = ""
-
-                if "originalEventId" in payload:
-                    event_id = payload["originalEventId"]["stringValue"]
-
-                if "originalLogGroup" in payload:
-                    log_group_name = payload["originalLogGroup"]["stringValue"]
-
-                if "originalLogStream" in payload:
-                    log_stream_name = payload["originalLogStream"]["stringValue"]
-
-                es_event["fields"]["log"]["file"]["path"] = f"{log_group_name}/{log_stream_name}"
-
-                es_event["fields"]["aws"] = {
-                    "cloudwatch_logs": {
-                        "group_name": log_group_name,
-                        "stream_name": log_stream_name,
-                        "event_id": event_id,
-                    }
+            es_event["fields"]["aws"] = {
+                "cloudwatch_logs": {
+                    "group_name": log_group_name,
+                    "stream_name": log_stream_name,
+                    "event_id": event_id,
                 }
-            else:
-                es_event["fields"]["log"]["file"]["path"] = get_queue_url_from_sqs_arn(sqs_record["eventSourceARN"])
+            }
+        else:
+            es_event["fields"]["log"]["file"]["path"] = get_queue_url_from_sqs_arn(input_id)
 
-                message_id = sqs_record["messageId"]
+            message_id = sqs_record["messageId"]
 
-                if "originalMessageId" in payload:
-                    message_id = payload["originalMessageId"]["stringValue"]
+            if "originalMessageId" in payload:
+                message_id = payload["originalMessageId"]["stringValue"]
 
-                es_event["fields"]["aws"] = {
-                    "sqs": {
-                        "name": queue_name,
-                        "message_id": message_id,
-                    }
+            es_event["fields"]["aws"] = {
+                "sqs": {
+                    "name": queue_name,
+                    "message_id": message_id,
                 }
+            }
 
-            es_event["fields"]["cloud"]["region"] = aws_region
+        es_event["fields"]["cloud"]["region"] = aws_region
 
-            yield es_event, ending_offset, sqs_record_n
+        yield es_event, ending_offset

--- a/shippers/es.py
+++ b/shippers/es.py
@@ -164,7 +164,7 @@ class ElasticsearchShipper(CommonShipper):
 
         return
 
-    def flush(self) -> Any:
+    def flush(self) -> None:
         if len(self._bulk_actions) > 0:
             errors = es_bulk(self._es_client, self._bulk_actions, **self._bulk_kwargs)
             self._handle_outcome(errors=errors)

--- a/shippers/es.py
+++ b/shippers/es.py
@@ -173,7 +173,7 @@ class ElasticsearchShipper(CommonShipper):
 
         return
 
-    def discover_dataset(self, event: Dict[str, Any]) -> None:
+    def discover_dataset(self, event: Dict[str, Any], at_record: int = 0) -> None:
         if self._es_index_or_datastream_name != "":
             if self._es_index_or_datastream_name.startswith("logs-"):
                 datastream_components = self._es_index_or_datastream_name.split("-")
@@ -195,10 +195,10 @@ class ElasticsearchShipper(CommonShipper):
         else:
             self._namespace = "default"
 
-            if "Records" not in event or len(event["Records"]) < 1 or "body" not in event["Records"][0]:
+            if "Records" not in event or len(event["Records"]) < at_record or "body" not in event["Records"][at_record]:
                 self._dataset = "generic"
             else:
-                body: str = event["Records"][0]["body"]
+                body: str = event["Records"][at_record]["body"]
                 s3_object_key: str = ""
                 try:
                     json_body: Dict[str, Any] = json.loads(body)

--- a/tests/handlers/aws/test_handler.py
+++ b/tests/handlers/aws/test_handler.py
@@ -120,7 +120,7 @@ class TestLambdaHandlerFailure(TestCase):
                 {
                     "messageAttributes": {
                         "config": {"stringValue": "ADD_CONFIG_STRING_HERE", "dataType": "String"},
-                        "originalEventSource": {
+                        "originalEventSourceARN": {
                             "stringValue": "dummy_aws_sqs",
                             "dataType": "String",
                         },
@@ -615,6 +615,921 @@ def _event_from_sqs_message(queue_attributes: dict[str, Any]) -> dict[str, Any]:
     return dict(Records=[message])
 
 
+def _create_cloudwatch_logs_group_and_stream(group_name: str, stream_name: str) -> Any:
+    logs_client = aws_stack.connect_to_service("logs")
+    logs_client.create_log_group(logGroupName=group_name)
+    logs_client.create_log_stream(logGroupName=group_name, logStreamName=stream_name)
+
+    return logs_client.describe_log_groups(logGroupNamePrefix=group_name)["logGroups"][0]
+
+
+def _event_to_cloudwatch_logs(group_name: str, stream_name: str, message_body: str) -> None:
+    now = int(datetime.datetime.utcnow().strftime("%s")) * 1000
+    logs_client = aws_stack.connect_to_service("logs")
+    logs_client.put_log_events(
+        logGroupName=group_name,
+        logStreamName=stream_name,
+        logEvents=[{"timestamp": now, "message": message_body}],
+    )
+
+
+def _event_from_cloudwatch_logs(group_name: str, stream_name: str) -> tuple[dict[str, Any], str]:
+    logs_client = aws_stack.connect_to_service("logs")
+    events = logs_client.get_log_events(logGroupName=group_name, logStreamName=stream_name)
+
+    assert "events" in events
+    assert len(events["events"]) == 1
+
+    event_id = "".join(random.choices(string.digits, k=56))
+    data_json = json.dumps(
+        {
+            "messageType": "DATA_MESSAGE",
+            "owner": "000000000000",
+            "logGroup": group_name,
+            "logStream": stream_name,
+            "subscriptionFilters": ["a-subscription-filter"],
+            "logEvents": [
+                {
+                    "id": event_id,
+                    "timestamp": events["events"][0]["timestamp"],
+                    "message": events["events"][0]["message"],
+                }
+            ],
+        }
+    )
+
+    data_gzip = gzip.compress(data_json.encode("UTF-8"))
+    data_base64encoded = base64.b64encode(data_gzip)
+
+    return {"event": {"awslogs": {"data": data_base64encoded}}}, event_id
+
+
+def _event_to_sqs_message(queue_attributes: dict[str, Any], message_body: str) -> None:
+    sqs_client = aws_stack.connect_to_service("sqs")
+
+    sqs_client.send_message(
+        QueueUrl=queue_attributes["QueueUrl"],
+        MessageBody=message_body,
+    )
+
+
+def _s3_event_to_sqs_message(queue_attributes: dict[str, Any], filename: str) -> None:
+    sqs_client = aws_stack.connect_to_service("sqs")
+
+    sqs_client.send_message(
+        QueueUrl=queue_attributes["QueueUrl"],
+        MessageBody=json.dumps(
+            {
+                "Records": [
+                    {
+                        "eventVersion": "2.1",
+                        "eventSource": "aws:s3",
+                        "awsRegion": "eu-central-1",
+                        "eventTime": "2021-09-08T18:34:25.042Z",
+                        "eventName": "ObjectCreated:Put",
+                        "s3": {
+                            "s3SchemaVersion": "1.0",
+                            "configurationId": "test-bucket",
+                            "bucket": {
+                                "name": "test-bucket",
+                                "arn": "arn:aws:s3:::test-bucket",
+                            },
+                            "object": {
+                                "key": f"{filename}",
+                            },
+                        },
+                    }
+                ]
+            }
+        ),
+    )
+
+
+@pytest.mark.integration
+class TestLambdaHandlerSuccessMixedInput(TestCase):
+    def setUp(self) -> None:
+        docker_client = docker.from_env()
+        localstack.utils.aws.aws_stack.BOTO_CLIENTS_CACHE = {}
+
+        self._localstack_container = docker_client.containers.run(
+            "localstack/localstack",
+            detach=True,
+            environment=["SERVICES=logs,s3,sqs,secretsmanager"],
+            ports={"4566/tcp": None},
+        )
+
+        _wait_for_container(self._localstack_container, "4566/tcp")
+
+        self._LOGS_BACKEND = os.environ.get("S3_BACKEND", "")
+        self._S3_BACKEND = os.environ.get("S3_BACKEND", "")
+        self._SQS_BACKEND = os.environ.get("SQS_BACKEND", "")
+        self._SECRETSMANAGER_BACKEND = os.environ.get("SECRETSMANAGER_BACKEND", "")
+
+        self._LOCALSTACK_HOST_PORT: str = self._localstack_container.ports["4566/tcp"][0]["HostPort"]
+
+        os.environ["LOGS_BACKEND"] = f"http://localhost:{self._LOCALSTACK_HOST_PORT}"
+        os.environ["S3_BACKEND"] = f"http://localhost:{self._LOCALSTACK_HOST_PORT}"
+        os.environ["SQS_BACKEND"] = f"http://localhost:{self._LOCALSTACK_HOST_PORT}"
+        os.environ["SECRETSMANAGER_BACKEND"] = f"http://localhost:{self._LOCALSTACK_HOST_PORT}"
+
+        _wait_for_localstack_service(aws_stack.connect_to_service(service_name="logs").describe_log_groups)
+
+        _wait_for_localstack_service(aws_stack.connect_to_service(service_name="s3").list_buckets)
+
+        _wait_for_localstack_service(aws_stack.connect_to_service(service_name="sqs").list_queues)
+
+        _wait_for_localstack_service(aws_stack.connect_to_service(service_name="secretsmanager").list_secrets)
+
+        self._ELASTIC_USER: str = "elastic"
+        self._ELASTIC_PASSWORD: str = "password"
+
+        self._secret_arn = _create_secrets(
+            "es_secrets",
+            {"username": self._ELASTIC_USER, "password": self._ELASTIC_PASSWORD},
+            self._LOCALSTACK_HOST_PORT,
+        )
+
+        self._elastic_container = docker_client.containers.run(
+            "docker.elastic.co/elasticsearch/elasticsearch:7.16.3",
+            detach=True,
+            environment=[
+                "ES_JAVA_OPTS=-Xms1g -Xmx1g",
+                f"ELASTIC_PASSWORD={self._ELASTIC_PASSWORD}",
+                "xpack.security.enabled=true",
+                "discovery.type=single-node",
+                "network.bind_host=0.0.0.0",
+                "logger.org.elasticsearch=DEBUG",
+            ],
+            ports={"9200/tcp": None},
+        )
+
+        _wait_for_container(self._elastic_container, "9200/tcp")
+
+        self._ES_HOST_PORT: str = self._elastic_container.ports["9200/tcp"][0]["HostPort"]
+
+        self._es_client = Elasticsearch(
+            hosts=[f"127.0.0.1:{self._ES_HOST_PORT}"],
+            scheme="http",
+            http_auth=(self._ELASTIC_USER, self._ELASTIC_PASSWORD),
+            timeout=30,
+            max_retries=10,
+            retry_on_timeout=True,
+            raise_on_error=False,
+            raise_on_exception=False,
+        )
+
+        while not self._es_client.ping():
+            time.sleep(1)
+
+        while True:
+            cluster_health = self._es_client.cluster.health(wait_for_status="green")
+            if "status" in cluster_health and cluster_health["status"] == "green":
+                break
+
+            time.sleep(1)
+
+        self._source_cloudwatch_logs_group_info = _create_cloudwatch_logs_group_and_stream(
+            group_name="source-group", stream_name="source-stream"
+        )
+
+        self._continuing_queue_info = testutil.create_sqs_queue("continuing-queue")
+        self._replay_queue_info = testutil.create_sqs_queue("replay-queue")
+        self._source_s3_queue_info = testutil.create_sqs_queue("source-s3-sqs-queue")
+        self._source_sqs_queue_info = testutil.create_sqs_queue("source-sqs-queue")
+
+        self._config_yaml: str = f"""
+        inputs:
+          - type: "cloudwatch-logs"
+            id: "{self._source_cloudwatch_logs_group_info["arn"]}"
+            tags:
+              - "tag1"
+              - "tag2"
+              - "tag3"
+            outputs:
+              - type: "elasticsearch"
+                args:
+                  elasticsearch_url: "http://127.0.0.1:{self._ES_HOST_PORT}"
+                  username: "{self._secret_arn}:username"
+                  password: "{self._secret_arn}:password"
+          - type: "s3-sqs"
+            id: "{self._source_s3_queue_info["QueueArn"]}"
+            tags:
+              - "tag1"
+              - "tag2"
+              - "tag3"
+            outputs:
+              - type: "elasticsearch"
+                args:
+                  elasticsearch_url: "http://127.0.0.1:{self._ES_HOST_PORT}"
+                  username: "{self._secret_arn}:username"
+                  password: "{self._secret_arn}:password"
+                  es_index_or_datastream_name: logs-generic-default
+          - type: "sqs"
+            id: "{self._source_sqs_queue_info["QueueArn"]}"
+            tags:
+              - "tag1"
+              - "tag2"
+              - "tag3"
+            outputs:
+              - type: "elasticsearch"
+                args:
+                  elasticsearch_url: "http://127.0.0.1:{self._ES_HOST_PORT}"
+                  username: "{self._secret_arn}:username"
+                  password: "{self._secret_arn}:password"
+                """
+
+        _upload_content_to_bucket(
+            content=self._config_yaml,
+            content_type="text/plain",
+            bucket_name="config-bucket",
+            key_name="folder/config.yaml",
+        )
+
+        self._cloudwatch_log: str = (
+            '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": "trigger"}\n'
+            '{"ecs": {"version": "1.6.0"}, "log": {"logger": '
+            '"root", "origin": {"file": {"line": 30, "name": "handler.py"}, "function": "lambda_handler"}, '
+            '"original": "trigger"}}\n'
+        )
+
+        _upload_content_to_bucket(
+            content=gzip.compress(self._cloudwatch_log.encode("UTF-8")),
+            content_type="application/x-gzip",
+            bucket_name="test-bucket",
+            key_name="exportedlogs/uuid/yyyy-mm-dd-[$LATEST]hash/000000.gz",
+        )
+
+        os.environ["S3_CONFIG_FILE"] = "s3://config-bucket/folder/config.yaml"
+        os.environ["SQS_CONTINUE_URL"] = self._continuing_queue_info["QueueUrl"]
+        os.environ["SQS_REPLAY_URL"] = self._replay_queue_info["QueueUrl"]
+
+    def tearDown(self) -> None:
+        os.environ["LOGS_BACKEND"] = self._LOGS_BACKEND
+        os.environ["S3_BACKEND"] = self._S3_BACKEND
+        os.environ["SQS_BACKEND"] = self._SQS_BACKEND
+        os.environ["SECRETSMANAGER_BACKEND"] = self._SECRETSMANAGER_BACKEND
+
+        del os.environ["S3_CONFIG_FILE"]
+        del os.environ["SQS_CONTINUE_URL"]
+        del os.environ["SQS_REPLAY_URL"]
+
+        self._elastic_container.stop()
+        self._elastic_container.remove()
+
+        self._localstack_container.stop()
+        self._localstack_container.remove()
+
+    @mock.patch("handlers.aws.handler._completion_grace_period", 1)
+    def test_lambda_handler_replay(self) -> None:
+        filename: str = "exportedlogs/uuid/yyyy-mm-dd-[$LATEST]hash/000000.gz"
+        with mock.patch("storage.S3Storage._s3_client", _mock_awsclient(service_name="s3")):
+            with mock.patch("handlers.aws.utils.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
+                with mock.patch(
+                    "handlers.aws.utils.get_cloudwatch_logs_client",
+                    lambda: _mock_awsclient(service_name="logs"),
+                ):
+                    with mock.patch(
+                        "share.secretsmanager._get_aws_sm_client",
+                        lambda region_name: _mock_awsclient(service_name="secretsmanager", region_name=region_name),
+                    ):
+                        _s3_event_to_sqs_message(queue_attributes=self._source_s3_queue_info, filename=filename)
+                        event_s3 = _event_from_sqs_message(queue_attributes=self._source_s3_queue_info)
+
+                        _event_to_sqs_message(
+                            queue_attributes=self._source_sqs_queue_info, message_body=self._cloudwatch_log
+                        )
+                        event_sqs = _event_from_sqs_message(queue_attributes=self._source_sqs_queue_info)
+
+                        message_id = event_sqs["Records"][0]["messageId"]
+                        src: str = f"source-sqs-queue{message_id}"
+                        hex_prefix_sqs = hashlib.sha256(src.encode("UTF-8")).hexdigest()[:10]
+
+                        _event_to_cloudwatch_logs(
+                            group_name="source-group",
+                            stream_name="source-stream",
+                            message_body=self._cloudwatch_log,
+                        )
+                        event_cloudwatch_logs, event_id_cloudwatch_logs = _event_from_cloudwatch_logs(
+                            group_name="source-group", stream_name="source-stream"
+                        )
+
+                        src = f"source-groupsource-stream{event_id_cloudwatch_logs}"
+                        hex_prefix_cloudwatch_logs = hashlib.sha256(src.encode("UTF-8")).hexdigest()[:10]
+
+                        # Create an expected id for s3-sqs so that es.send will fail
+                        self._es_client.index(
+                            index="logs-generic-default",
+                            op_type="create",
+                            id="e69eaefedb-000000000000",
+                            document={"@timestamp": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")},
+                        )
+
+                        # Create an expected id so that es.send will fail
+                        self._es_client.index(
+                            index="logs-generic-default",
+                            op_type="create",
+                            id=f"{hex_prefix_sqs}-000000000000",
+                            document={"@timestamp": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")},
+                        )
+
+                        # Create an expected id for cloudwatch-logs so that es.send will fail
+                        self._es_client.index(
+                            index="logs-generic-default",
+                            op_type="create",
+                            id=f"{hex_prefix_cloudwatch_logs}-000000000000",
+                            document={"@timestamp": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")},
+                        )
+
+                        self._es_client.indices.refresh(index="logs-generic-default")
+
+                        res = self._es_client.search(
+                            index="logs-generic-default",
+                            query={
+                                "ids": {
+                                    "values": [
+                                        "e69eaefedb-000000000086",
+                                        f"{hex_prefix_sqs}-000000000086",
+                                        f"{hex_prefix_cloudwatch_logs}-000000000086",
+                                    ]
+                                }
+                            },
+                        )
+                        assert res["hits"]["total"] == {"value": 0, "relation": "eq"}
+
+                        ctx = ContextMock(remaining_time_in_millis=2)
+
+                        first_call = handler(event_s3, ctx)  # type:ignore
+
+                        assert first_call == "completed"
+
+                        self._es_client.indices.refresh(index="logs-generic-default")
+                        res = self._es_client.search(
+                            index="logs-generic-default",
+                            query={"ids": {"values": ["e69eaefedb-000000000086"]}},
+                        )
+
+                        assert (
+                            res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                            == '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": '
+                            '{"line": 30, "name": "handler.py"}, "function": "lambda_handler"}, '
+                            '"original": "trigger"}}'
+                        )
+
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                            "offset": 86,
+                            "file": {"path": f"https://test-bucket.s3.eu-central-1.amazonaws.com/{filename}"},
+                        }
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                            "s3": {
+                                "bucket": {"name": "test-bucket", "arn": "arn:aws:s3:::test-bucket"},
+                                "object": {"key": f"{filename}"},
+                            }
+                        }
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                            "provider": "aws",
+                            "region": "eu-central-1",
+                        }
+
+                        assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                            "preserve_original_event",
+                            "forwarded",
+                            "generic",
+                            "tag1",
+                            "tag2",
+                            "tag3",
+                        ]
+
+                        first_replayed_event = _event_from_sqs_message(queue_attributes=self._replay_queue_info)
+
+                        second_call = handler(event_sqs, ctx)  # type:ignore
+
+                        assert second_call == "completed"
+
+                        self._es_client.indices.refresh(index="logs-generic-default")
+                        res = self._es_client.search(
+                            index="logs-generic-default",
+                            query={"ids": {"values": [f"{hex_prefix_sqs}-000000000086"]}},
+                        )
+
+                        assert (
+                            res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                            == '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": '
+                            '{"line": 30, "name": "handler.py"}, "function": "lambda_handler"}, '
+                            '"original": "trigger"}}'
+                        )
+
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                            "offset": 86,
+                            "file": {"path": self._source_sqs_queue_info["QueueUrl"]},
+                        }
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                            "sqs": {
+                                "name": "source-sqs-queue",
+                                "message_id": message_id,
+                            }
+                        }
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                            "provider": "aws",
+                            "region": "us-east-1",
+                        }
+
+                        assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                            "preserve_original_event",
+                            "forwarded",
+                            "generic",
+                            "tag1",
+                            "tag2",
+                            "tag3",
+                        ]
+
+                        second_replayed_event = _event_from_sqs_message(queue_attributes=self._replay_queue_info)
+
+                        third_call = handler(event_cloudwatch_logs, ctx)  # type:ignore
+
+                        assert third_call == "completed"
+
+                        self._es_client.indices.refresh(index="logs-generic-default")
+                        res = self._es_client.search(
+                            index="logs-generic-default",
+                            query={"ids": {"values": [f"{hex_prefix_cloudwatch_logs}-000000000086"]}},
+                        )
+
+                        assert (
+                            res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                            == '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": '
+                            '{"line": 30, "name": "handler.py"}, "function": "lambda_handler"}, '
+                            '"original": "trigger"}}'
+                        )
+
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                            "offset": 86,
+                            "file": {"path": "source-group/source-stream"},
+                        }
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                            "cloudwatch_logs": {
+                                "group_name": "source-group",
+                                "stream_name": "source-stream",
+                                "event_id": event_id_cloudwatch_logs,
+                            }
+                        }
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                            "provider": "aws",
+                            "region": "us-east-1",
+                        }
+
+                        assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                            "preserve_original_event",
+                            "forwarded",
+                            "generic",
+                            "tag1",
+                            "tag2",
+                            "tag3",
+                        ]
+
+                        # Remove the expected id for s3-sqs so that it can be replayed
+                        self._es_client.delete_by_query(
+                            index="logs-generic-default",
+                            body={"query": {"match": {"_id": "e69eaefedb-000000000000"}}},
+                        )
+
+                        # Remove the expected id for sqs so that it can be replayed
+                        self._es_client.delete_by_query(
+                            index="logs-generic-default",
+                            body={"query": {"match": {"_id": f"{hex_prefix_sqs}-000000000000"}}},
+                        )
+
+                        # Remove the expected id so that it can be replayed
+                        self._es_client.delete_by_query(
+                            index="logs-generic-default",
+                            body={"query": {"match": {"_id": f"{hex_prefix_cloudwatch_logs}-000000000000"}}},
+                        )
+
+                        self._es_client.indices.refresh(index="logs-generic-default")
+
+                        third_replayed_event = _event_from_sqs_message(queue_attributes=self._replay_queue_info)
+
+                        fourth_call = handler(first_replayed_event, ctx)  # type:ignore
+
+                        assert fourth_call == "replayed"
+
+                        self._es_client.indices.refresh(index="logs-generic-default")
+                        assert self._es_client.count(index="logs-generic-default")["count"] == 4
+
+                        res = self._es_client.search(
+                            index="logs-generic-default",
+                            query={"ids": {"values": ["e69eaefedb-000000000000"]}},
+                        )
+                        assert (
+                            res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                            == '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": '
+                            '"trigger"}'
+                        )
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                            "offset": 0,
+                            "file": {"path": f"https://test-bucket.s3.eu-central-1.amazonaws.com/{filename}"},
+                        }
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                            "s3": {
+                                "bucket": {"name": "test-bucket", "arn": "arn:aws:s3:::test-bucket"},
+                                "object": {"key": f"{filename}"},
+                            }
+                        }
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                            "provider": "aws",
+                            "region": "eu-central-1",
+                        }
+
+                        assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                            "preserve_original_event",
+                            "forwarded",
+                            "generic",
+                            "tag1",
+                            "tag2",
+                            "tag3",
+                        ]
+
+                        fifth_call = handler(second_replayed_event, ctx)  # type:ignore
+
+                        assert fifth_call == "replayed"
+
+                        self._es_client.indices.refresh(index="logs-generic-default")
+                        assert self._es_client.count(index="logs-generic-default")["count"] == 5
+
+                        res = self._es_client.search(
+                            index="logs-generic-default",
+                            query={"ids": {"values": [f"{hex_prefix_sqs}-000000000000"]}},
+                        )
+                        assert (
+                            res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                            == '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": '
+                            '"trigger"}'
+                        )
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                            "offset": 0,
+                            "file": {"path": self._source_sqs_queue_info["QueueUrl"]},
+                        }
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                            "sqs": {
+                                "name": "source-sqs-queue",
+                                "message_id": message_id,
+                            }
+                        }
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                            "provider": "aws",
+                            "region": "us-east-1",
+                        }
+
+                        assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                            "preserve_original_event",
+                            "forwarded",
+                            "generic",
+                            "tag1",
+                            "tag2",
+                            "tag3",
+                        ]
+
+                        sixth_call = handler(third_replayed_event, ctx)  # type:ignore
+
+                        assert sixth_call == "replayed"
+
+                        self._es_client.indices.refresh(index="logs-generic-default")
+                        assert self._es_client.count(index="logs-generic-default")["count"] == 6
+
+                        res = self._es_client.search(
+                            index="logs-generic-default",
+                            query={"ids": {"values": [f"{hex_prefix_cloudwatch_logs}-000000000000"]}},
+                        )
+                        assert (
+                            res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                            == '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": '
+                            '"trigger"}'
+                        )
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                            "offset": 0,
+                            "file": {"path": "source-group/source-stream"},
+                        }
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                            "cloudwatch_logs": {
+                                "group_name": "source-group",
+                                "stream_name": "source-stream",
+                                "event_id": event_id_cloudwatch_logs,
+                            }
+                        }
+                        assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                            "provider": "aws",
+                            "region": "us-east-1",
+                        }
+
+                        assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                            "preserve_original_event",
+                            "forwarded",
+                            "generic",
+                            "tag1",
+                            "tag2",
+                            "tag3",
+                        ]
+
+    @mock.patch("handlers.aws.handler._completion_grace_period", 1)
+    def test_lambda_handler_continuing(self) -> None:
+        filename: str = "exportedlogs/uuid/yyyy-mm-dd-[$LATEST]hash/000000.gz"
+        with mock.patch("storage.S3Storage._s3_client", _mock_awsclient(service_name="s3")):
+            with mock.patch("handlers.aws.handler.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
+                with mock.patch("handlers.aws.utils.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
+                    with mock.patch(
+                        "handlers.aws.utils.get_cloudwatch_logs_client",
+                        lambda: _mock_awsclient(service_name="logs"),
+                    ):
+                        with mock.patch(
+                            "share.secretsmanager._get_aws_sm_client",
+                            lambda region_name: _mock_awsclient(service_name="secretsmanager", region_name=region_name),
+                        ):
+
+                            ctx = ContextMock()
+
+                            _s3_event_to_sqs_message(queue_attributes=self._source_s3_queue_info, filename=filename)
+                            event_s3 = _event_from_sqs_message(queue_attributes=self._source_s3_queue_info)
+
+                            _event_to_sqs_message(
+                                queue_attributes=self._source_sqs_queue_info, message_body=self._cloudwatch_log
+                            )
+                            event_sqs = _event_from_sqs_message(queue_attributes=self._source_sqs_queue_info)
+
+                            message_id = event_sqs["Records"][0]["messageId"]
+                            src: str = f"source-sqs-queue{message_id}"
+                            hex_prefix_sqs = hashlib.sha256(src.encode("UTF-8")).hexdigest()[:10]
+
+                            _event_to_cloudwatch_logs(
+                                group_name="source-group",
+                                stream_name="source-stream",
+                                message_body=self._cloudwatch_log,
+                            )
+                            event_cloudwatch_logs, event_id_cloudwatch_logs = _event_from_cloudwatch_logs(
+                                group_name="source-group", stream_name="source-stream"
+                            )
+
+                            src = f"source-groupsource-stream{event_id_cloudwatch_logs}"
+                            hex_prefix_cloudwatch_logs = hashlib.sha256(src.encode("UTF-8")).hexdigest()[:10]
+
+                            first_call = handler(event_s3, ctx)  # type:ignore
+
+                            assert first_call == "continuing"
+
+                            self._es_client.indices.refresh(index="logs-generic-default")
+                            assert self._es_client.count(index="logs-generic-default")["count"] == 1
+
+                            res = self._es_client.search(
+                                index="logs-generic-default",
+                                query={"ids": {"values": ["e69eaefedb-000000000000"]}},
+                            )
+
+                            assert (
+                                res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                                == '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": '
+                                '"trigger"}'
+                            )
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                                "offset": 0,
+                                "file": {"path": f"https://test-bucket.s3.eu-central-1.amazonaws.com/{filename}"},
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                                "s3": {
+                                    "bucket": {"name": "test-bucket", "arn": "arn:aws:s3:::test-bucket"},
+                                    "object": {"key": f"{filename}"},
+                                }
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                                "provider": "aws",
+                                "region": "eu-central-1",
+                            }
+
+                            assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                                "preserve_original_event",
+                                "forwarded",
+                                "generic",
+                                "tag1",
+                                "tag2",
+                                "tag3",
+                            ]
+
+                            first_continued_event = _event_from_sqs_message(
+                                queue_attributes=self._continuing_queue_info
+                            )
+
+                            second_call = handler(event_sqs, ctx)  # type:ignore
+
+                            assert second_call == "continuing"
+
+                            self._es_client.indices.refresh(index="logs-generic-default")
+                            assert self._es_client.count(index="logs-generic-default")["count"] == 2
+
+                            res = self._es_client.search(
+                                index="logs-generic-default",
+                                query={"ids": {"values": [f"{hex_prefix_sqs}-000000000000"]}},
+                            )
+                            assert (
+                                res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                                == '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", '
+                                '"message": "trigger"}'
+                            )
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                                "offset": 0,
+                                "file": {"path": self._source_sqs_queue_info["QueueUrl"]},
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                                "sqs": {
+                                    "name": "source-sqs-queue",
+                                    "message_id": message_id,
+                                }
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                                "provider": "aws",
+                                "region": "us-east-1",
+                            }
+
+                            assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                                "preserve_original_event",
+                                "forwarded",
+                                "generic",
+                                "tag1",
+                                "tag2",
+                                "tag3",
+                            ]
+
+                            second_continued_event = _event_from_sqs_message(
+                                queue_attributes=self._continuing_queue_info
+                            )
+
+                            third_call = handler(event_cloudwatch_logs, ctx)  # type:ignore
+
+                            assert third_call == "continuing"
+
+                            self._es_client.indices.refresh(index="logs-generic-default")
+                            assert self._es_client.count(index="logs-generic-default")["count"] == 3
+
+                            res = self._es_client.search(
+                                index="logs-generic-default",
+                                query={"ids": {"values": [f"{hex_prefix_cloudwatch_logs}-000000000000"]}},
+                            )
+                            assert (
+                                res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                                == '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": '
+                                '"trigger"}'
+                            )
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                                "offset": 0,
+                                "file": {"path": "source-group/source-stream"},
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                                "cloudwatch_logs": {
+                                    "group_name": "source-group",
+                                    "stream_name": "source-stream",
+                                    "event_id": event_id_cloudwatch_logs,
+                                }
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                                "provider": "aws",
+                                "region": "us-east-1",
+                            }
+
+                            assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                                "preserve_original_event",
+                                "forwarded",
+                                "generic",
+                                "tag1",
+                                "tag2",
+                                "tag3",
+                            ]
+
+                            third_continued_event = _event_from_sqs_message(
+                                queue_attributes=self._continuing_queue_info
+                            )
+
+                            continued_events = dict(
+                                Records=[
+                                    first_continued_event["Records"][0],
+                                    second_continued_event["Records"][0],
+                                    third_continued_event["Records"][0],
+                                ]
+                            )
+
+                            ctx = ContextMock(remaining_time_in_millis=2)
+                            fourth_call = handler(continued_events, ctx)  # type:ignore
+
+                            assert fourth_call == "completed"
+
+                            self._es_client.indices.refresh(index="logs-generic-default")
+                            assert self._es_client.count(index="logs-generic-default")["count"] == 6
+
+                            res = self._es_client.search(
+                                index="logs-generic-default",
+                                query={"ids": {"values": ["e69eaefedb-000000000086"]}},
+                            )
+
+                            assert (
+                                res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                                == '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": '
+                                '{"line": 30, "name": "handler.py"}, "function": "lambda_handler"}, '
+                                '"original": "trigger"}}'
+                            )
+
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                                "offset": 86,
+                                "file": {"path": f"https://test-bucket.s3.eu-central-1.amazonaws.com/{filename}"},
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                                "s3": {
+                                    "bucket": {"name": "test-bucket", "arn": "arn:aws:s3:::test-bucket"},
+                                    "object": {"key": f"{filename}"},
+                                }
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                                "provider": "aws",
+                                "region": "eu-central-1",
+                            }
+
+                            assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                                "preserve_original_event",
+                                "forwarded",
+                                "generic",
+                                "tag1",
+                                "tag2",
+                                "tag3",
+                            ]
+
+                            res = self._es_client.search(
+                                index="logs-generic-default",
+                                query={"ids": {"values": [f"{hex_prefix_sqs}-000000000086"]}},
+                            )
+
+                            assert (
+                                res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                                == '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": '
+                                '{"line": 30, "name": "handler.py"}, "function": "lambda_handler"}, '
+                                '"original": "trigger"}}'
+                            )
+
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                                "offset": 86,
+                                "file": {"path": self._source_sqs_queue_info["QueueUrl"]},
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                                "sqs": {
+                                    "name": "source-sqs-queue",
+                                    "message_id": message_id,
+                                }
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                                "provider": "aws",
+                                "region": "us-east-1",
+                            }
+
+                            assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                                "preserve_original_event",
+                                "forwarded",
+                                "generic",
+                                "tag1",
+                                "tag2",
+                                "tag3",
+                            ]
+
+                            res = self._es_client.search(
+                                index="logs-generic-default",
+                                query={"ids": {"values": [f"{hex_prefix_cloudwatch_logs}-000000000086"]}},
+                            )
+
+                            assert (
+                                res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                                == '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": '
+                                '{"line": 30, "name": "handler.py"}, "function": "lambda_handler"}, '
+                                '"original": "trigger"}}'
+                            )
+
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                                "offset": 86,
+                                "file": {"path": "source-group/source-stream"},
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                                "cloudwatch_logs": {
+                                    "group_name": "source-group",
+                                    "stream_name": "source-stream",
+                                    "event_id": event_id_cloudwatch_logs,
+                                }
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                                "provider": "aws",
+                                "region": "us-east-1",
+                            }
+
+                            assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                                "preserve_original_event",
+                                "forwarded",
+                                "generic",
+                                "tag1",
+                                "tag2",
+                                "tag3",
+                            ]
+
+
 @pytest.mark.integration
 class TestLambdaHandlerSuccessKinesisDataStream(TestCase):
     def setUp(self) -> None:
@@ -800,159 +1715,156 @@ class TestLambdaHandlerSuccessKinesisDataStream(TestCase):
 
     def test_lambda_handler_kinesis(self) -> None:
         with mock.patch("storage.S3Storage._s3_client", _mock_awsclient(service_name="s3")):
-            with mock.patch("handlers.aws.s3_sqs_trigger.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
-                with mock.patch(
-                    "share.secretsmanager._get_aws_sm_client",
-                    lambda region_name: _mock_awsclient(service_name="secretsmanager", region_name=region_name),
-                ):
+            with mock.patch(
+                "share.secretsmanager._get_aws_sm_client",
+                lambda region_name: _mock_awsclient(service_name="secretsmanager", region_name=region_name),
+            ):
 
-                    shards_paginator = self._kinesis_client.get_paginator("list_shards")
-                    shards_available = [
-                        shard
-                        for shard in shards_paginator.paginate(
-                            StreamName=self._kinesis_stream.stream_name,
-                            ShardFilter={"Type": "FROM_TRIM_HORIZON", "Timestamp": datetime.datetime(2015, 1, 1)},
-                            PaginationConfig={
-                                "MaxItems": 1,
-                                "PageSize": 1,
-                            },
-                        )
-                    ]
-
-                    assert len(shards_available) == 1 and len(shards_available[0]["Shards"]) == 1
-
-                    shard_iterator = self._kinesis_client.get_shard_iterator(
+                shards_paginator = self._kinesis_client.get_paginator("list_shards")
+                shards_available = [
+                    shard
+                    for shard in shards_paginator.paginate(
                         StreamName=self._kinesis_stream.stream_name,
-                        ShardId=shards_available[0]["Shards"][0]["ShardId"],
-                        ShardIteratorType="TRIM_HORIZON",
-                        Timestamp=datetime.datetime(2015, 1, 1),
+                        ShardFilter={"Type": "FROM_TRIM_HORIZON", "Timestamp": datetime.datetime(2015, 1, 1)},
+                        PaginationConfig={
+                            "MaxItems": 1,
+                            "PageSize": 1,
+                        },
                     )
+                ]
 
-                    records = self._kinesis_client.get_records(ShardIterator=shard_iterator["ShardIterator"], Limit=2)
+                assert len(shards_available) == 1 and len(shards_available[0]["Shards"]) == 1
 
-                    ctx = ContextMock()
-                    event = self._event_from_kinesis_records(
-                        records=records, stream_attribute=self._source_kinesis_info
-                    )
+                shard_iterator = self._kinesis_client.get_shard_iterator(
+                    StreamName=self._kinesis_stream.stream_name,
+                    ShardId=shards_available[0]["Shards"][0]["ShardId"],
+                    ShardIteratorType="TRIM_HORIZON",
+                    Timestamp=datetime.datetime(2015, 1, 1),
+                )
 
-                    first_call = handler(event, ctx)  # type:ignore
+                records = self._kinesis_client.get_records(ShardIterator=shard_iterator["ShardIterator"], Limit=2)
 
-                    assert first_call == {
-                        "batchItemFailures": [{"itemIdentifier": event["Records"][1]["kinesis"]["sequenceNumber"]}]
+                ctx = ContextMock()
+                event = self._event_from_kinesis_records(records=records, stream_attribute=self._source_kinesis_info)
+
+                first_call = handler(event, ctx)  # type:ignore
+
+                assert first_call == {
+                    "batchItemFailures": [{"itemIdentifier": event["Records"][1]["kinesis"]["sequenceNumber"]}]
+                }
+
+                self._es_client.indices.refresh(index="logs-generic-default")
+                assert self._es_client.count(index="logs-generic-default")["count"] == 2
+
+                res = self._es_client.search(index="logs-generic-default", sort="_seq_no")
+                assert res["hits"]["total"] == {"value": 2, "relation": "eq"}
+
+                assert (
+                    res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                    == '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": "trigger"}'
+                )
+                assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                    "offset": 0,
+                    "file": {"path": self._source_kinesis_info["StreamDescription"]["StreamARN"]},
+                }
+                assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                    "kinesis": {
+                        "type": "stream",
+                        "name": self._kinesis_stream.stream_name,
+                        "sequence_number": event["Records"][0]["kinesis"]["sequenceNumber"],
                     }
+                }
+                assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                    "provider": "aws",
+                    "region": "us-east-1",
+                }
 
-                    self._es_client.indices.refresh(index="logs-generic-default")
-                    assert self._es_client.count(index="logs-generic-default")["count"] == 2
+                assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                    "preserve_original_event",
+                    "forwarded",
+                    "generic",
+                    "tag1",
+                    "tag2",
+                    "tag3",
+                ]
 
-                    res = self._es_client.search(index="logs-generic-default", sort="_seq_no")
-                    assert res["hits"]["total"] == {"value": 2, "relation": "eq"}
+                assert (
+                    res["hits"]["hits"][1]["_source"]["fields"]["message"]
+                    == '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": {"line": 30, '
+                    '"name": "handler.py"}, "function": "lambda_handler"}, "original": "trigger"}}'
+                )
 
-                    assert (
-                        res["hits"]["hits"][0]["_source"]["fields"]["message"]
-                        == '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": "trigger"}'
-                    )
-                    assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
-                        "offset": 0,
-                        "file": {"path": self._source_kinesis_info["StreamDescription"]["StreamARN"]},
+                assert res["hits"]["hits"][1]["_source"]["fields"]["log"] == {
+                    "offset": 86,
+                    "file": {"path": self._source_kinesis_info["StreamDescription"]["StreamARN"]},
+                }
+                assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                    "kinesis": {
+                        "type": "stream",
+                        "name": self._kinesis_stream.stream_name,
+                        "sequence_number": event["Records"][0]["kinesis"]["sequenceNumber"],
                     }
-                    assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
-                        "kinesis": {
-                            "type": "stream",
-                            "name": self._kinesis_stream.stream_name,
-                            "sequence_number": event["Records"][0]["kinesis"]["sequenceNumber"],
-                        }
+                }
+                assert res["hits"]["hits"][1]["_source"]["fields"]["cloud"] == {
+                    "provider": "aws",
+                    "region": "us-east-1",
+                }
+
+                assert res["hits"]["hits"][1]["_source"]["tags"] == [
+                    "preserve_original_event",
+                    "forwarded",
+                    "generic",
+                    "tag1",
+                    "tag2",
+                    "tag3",
+                ]
+
+                event["Records"] = event["Records"][1:]
+                second_call = handler(event, ctx)  # type:ignore
+
+                assert second_call == {"batchItemFailures": []}
+
+                self._es_client.indices.refresh(index="logs-generic-default")
+                assert self._es_client.count(index="logs-generic-default")["count"] == 3
+
+                res = self._es_client.search(index="logs-generic-default", sort="_seq_no")
+                assert res["hits"]["total"] == {"value": 3, "relation": "eq"}
+
+                assert (
+                    res["hits"]["hits"][2]["_source"]["fields"]["message"]
+                    == '{"@timestamp":"2022-02-02T12:40:45.690Z","log.level":"warning","message":"no namespace set '
+                    'in config: using `default`","ecs":{"version":"1.6.0"} }'
+                )
+
+                assert res["hits"]["hits"][2]["_source"]["fields"]["log"] == {
+                    "offset": 0,
+                    "file": {"path": self._source_kinesis_info["StreamDescription"]["StreamARN"]},
+                }
+                assert res["hits"]["hits"][2]["_source"]["fields"]["aws"] == {
+                    "kinesis": {
+                        "type": "stream",
+                        "name": self._kinesis_stream.stream_name,
+                        "sequence_number": event["Records"][0]["kinesis"]["sequenceNumber"],
                     }
-                    assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
-                        "provider": "aws",
-                        "region": "us-east-1",
-                    }
+                }
+                assert res["hits"]["hits"][2]["_source"]["fields"]["cloud"] == {
+                    "provider": "aws",
+                    "region": "us-east-1",
+                }
 
-                    assert res["hits"]["hits"][0]["_source"]["tags"] == [
-                        "preserve_original_event",
-                        "forwarded",
-                        "generic",
-                        "tag1",
-                        "tag2",
-                        "tag3",
-                    ]
+                assert res["hits"]["hits"][2]["_source"]["tags"] == [
+                    "preserve_original_event",
+                    "forwarded",
+                    "generic",
+                    "tag1",
+                    "tag2",
+                    "tag3",
+                ]
 
-                    assert (
-                        res["hits"]["hits"][1]["_source"]["fields"]["message"]
-                        == '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": {"line": 30, '
-                        '"name": "handler.py"}, "function": "lambda_handler"}, "original": "trigger"}}'
-                    )
-
-                    assert res["hits"]["hits"][1]["_source"]["fields"]["log"] == {
-                        "offset": 86,
-                        "file": {"path": self._source_kinesis_info["StreamDescription"]["StreamARN"]},
-                    }
-                    assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
-                        "kinesis": {
-                            "type": "stream",
-                            "name": self._kinesis_stream.stream_name,
-                            "sequence_number": event["Records"][0]["kinesis"]["sequenceNumber"],
-                        }
-                    }
-                    assert res["hits"]["hits"][1]["_source"]["fields"]["cloud"] == {
-                        "provider": "aws",
-                        "region": "us-east-1",
-                    }
-
-                    assert res["hits"]["hits"][1]["_source"]["tags"] == [
-                        "preserve_original_event",
-                        "forwarded",
-                        "generic",
-                        "tag1",
-                        "tag2",
-                        "tag3",
-                    ]
-
-                    event["Records"] = event["Records"][1:]
-                    second_call = handler(event, ctx)  # type:ignore
-
-                    assert second_call == {"batchItemFailures": []}
-
-                    self._es_client.indices.refresh(index="logs-generic-default")
-                    assert self._es_client.count(index="logs-generic-default")["count"] == 3
-
-                    res = self._es_client.search(index="logs-generic-default", sort="_seq_no")
-                    assert res["hits"]["total"] == {"value": 3, "relation": "eq"}
-
-                    assert (
-                        res["hits"]["hits"][2]["_source"]["fields"]["message"]
-                        == '{"@timestamp":"2022-02-02T12:40:45.690Z","log.level":"warning","message":"no namespace set '
-                        'in config: using `default`","ecs":{"version":"1.6.0"} }'
-                    )
-
-                    assert res["hits"]["hits"][2]["_source"]["fields"]["log"] == {
-                        "offset": 0,
-                        "file": {"path": self._source_kinesis_info["StreamDescription"]["StreamARN"]},
-                    }
-                    assert res["hits"]["hits"][2]["_source"]["fields"]["aws"] == {
-                        "kinesis": {
-                            "type": "stream",
-                            "name": self._kinesis_stream.stream_name,
-                            "sequence_number": event["Records"][0]["kinesis"]["sequenceNumber"],
-                        }
-                    }
-                    assert res["hits"]["hits"][2]["_source"]["fields"]["cloud"] == {
-                        "provider": "aws",
-                        "region": "us-east-1",
-                    }
-
-                    assert res["hits"]["hits"][2]["_source"]["tags"] == [
-                        "preserve_original_event",
-                        "forwarded",
-                        "generic",
-                        "tag1",
-                        "tag2",
-                        "tag3",
-                    ]
-
-                    while "NextShardIterator" in records:
-                        records = self._kinesis_client.get_records(ShardIterator=records["NextShardIterator"], Limit=2)
-                        assert not records["Records"]
-                        break
+                while "NextShardIterator" in records:
+                    records = self._kinesis_client.get_records(ShardIterator=records["NextShardIterator"], Limit=2)
+                    assert not records["Records"]
+                    break
 
 
 @pytest.mark.integration
@@ -1235,7 +2147,7 @@ class TestLambdaHandlerSuccessS3SQS(TestCase):
     def test_lambda_handler_continuing(self) -> None:
         filename: str = "exportedlogs/uuid/yyyy-mm-dd-[$LATEST]hash/000000.gz"
         with mock.patch("storage.S3Storage._s3_client", _mock_awsclient(service_name="s3")):
-            with mock.patch("handlers.aws.s3_sqs_trigger.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
+            with mock.patch("handlers.aws.handler.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
                 with mock.patch("handlers.aws.utils.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
                     with mock.patch(
                         "share.secretsmanager._get_aws_sm_client",
@@ -1466,125 +2378,122 @@ class TestLambdaHandlerSuccessSQS(TestCase):
     def test_lambda_handler_replay(self) -> None:
         with mock.patch("storage.S3Storage._s3_client", _mock_awsclient(service_name="s3")):
             with mock.patch("handlers.aws.utils.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
-                with mock.patch("handlers.aws.sqs_trigger.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
-                    with mock.patch(
-                        "share.secretsmanager._get_aws_sm_client",
-                        lambda region_name: _mock_awsclient(service_name="secretsmanager", region_name=region_name),
-                    ):
-                        cloudwatch_log: str = (
-                            '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": "trigger"}\n'
-                            '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": {"line": 30, '
-                            '"name": "handler.py"}, "function": "lambda_handler"}, "original": "trigger"}}\n'
-                        )
+                with mock.patch(
+                    "share.secretsmanager._get_aws_sm_client",
+                    lambda region_name: _mock_awsclient(service_name="secretsmanager", region_name=region_name),
+                ):
+                    cloudwatch_log: str = (
+                        '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": "trigger"}\n'
+                        '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": {"line": 30, '
+                        '"name": "handler.py"}, "function": "lambda_handler"}, "original": "trigger"}}\n'
+                    )
 
-                        self._event_to_sqs_message(
-                            queue_attributes=self._source_queue_info, message_body=cloudwatch_log
-                        )
+                    _event_to_sqs_message(queue_attributes=self._source_queue_info, message_body=cloudwatch_log)
 
-                        event = _event_from_sqs_message(queue_attributes=self._source_queue_info)
+                    event = _event_from_sqs_message(queue_attributes=self._source_queue_info)
 
-                        message_id = event["Records"][0]["messageId"]
-                        src: str = f"source-queue{message_id}"
-                        hex_prefix = hashlib.sha256(src.encode("UTF-8")).hexdigest()[:10]
+                    message_id = event["Records"][0]["messageId"]
+                    src: str = f"source-queue{message_id}"
+                    hex_prefix = hashlib.sha256(src.encode("UTF-8")).hexdigest()[:10]
 
-                        # Create an expected id so that es.send will fail
-                        self._es_client.index(
-                            index="logs-generic-default",
-                            op_type="create",
-                            id=f"{hex_prefix}-000000000000",
-                            document={"@timestamp": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")},
-                        )
-                        self._es_client.indices.refresh(index="logs-generic-default")
+                    # Create an expected id so that es.send will fail
+                    self._es_client.index(
+                        index="logs-generic-default",
+                        op_type="create",
+                        id=f"{hex_prefix}-000000000000",
+                        document={"@timestamp": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")},
+                    )
+                    self._es_client.indices.refresh(index="logs-generic-default")
 
-                        ctx = ContextMock(remaining_time_in_millis=2)
+                    ctx = ContextMock(remaining_time_in_millis=2)
 
-                        first_call = handler(event, ctx)  # type:ignore
+                    first_call = handler(event, ctx)  # type:ignore
 
-                        assert first_call == "completed"
+                    assert first_call == "completed"
 
-                        # Remove the expected id so that it can be replayed
-                        self._es_client.delete_by_query(
-                            index="logs-generic-default",
-                            body={"query": {"match": {"_id": f"{hex_prefix}-000000000000"}}},
-                        )
-                        self._es_client.indices.refresh(index="logs-generic-default")
+                    # Remove the expected id so that it can be replayed
+                    self._es_client.delete_by_query(
+                        index="logs-generic-default",
+                        body={"query": {"match": {"_id": f"{hex_prefix}-000000000000"}}},
+                    )
+                    self._es_client.indices.refresh(index="logs-generic-default")
 
-                        assert self._es_client.count(index="logs-generic-default")["count"] == 1
+                    assert self._es_client.count(index="logs-generic-default")["count"] == 1
 
-                        res = self._es_client.search(index="logs-generic-default", sort="_seq_no")
-                        assert res["hits"]["total"] == {"value": 1, "relation": "eq"}
+                    res = self._es_client.search(index="logs-generic-default", sort="_seq_no")
+                    assert res["hits"]["total"] == {"value": 1, "relation": "eq"}
 
-                        assert (
-                            res["hits"]["hits"][0]["_source"]["fields"]["message"]
-                            == '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": {"line": '
-                            '30, "name": "handler.py"}, "function": "lambda_handler"}, "original": "trigger"}}'
-                        )
+                    assert (
+                        res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                        == '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": {"line": '
+                        '30, "name": "handler.py"}, "function": "lambda_handler"}, "original": "trigger"}}'
+                    )
 
-                        assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
-                            "offset": 86,
-                            "file": {"path": self._source_queue_info["QueueUrl"]},
+                    assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                        "offset": 86,
+                        "file": {"path": self._source_queue_info["QueueUrl"]},
+                    }
+                    assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                        "sqs": {
+                            "name": "source-queue",
+                            "message_id": message_id,
                         }
-                        assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
-                            "sqs": {
-                                "name": "source-queue",
-                                "message_id": message_id,
-                            }
+                    }
+                    assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                        "provider": "aws",
+                        "region": "us-east-1",
+                    }
+
+                    assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                        "preserve_original_event",
+                        "forwarded",
+                        "generic",
+                        "tag1",
+                        "tag2",
+                        "tag3",
+                    ]
+
+                    event = _event_from_sqs_message(queue_attributes=self._replay_queue_info)
+                    second_call = handler(event, ctx)  # type:ignore
+
+                    assert second_call == "replayed"
+
+                    self._es_client.indices.refresh(index="logs-generic-default")
+                    assert self._es_client.count(index="logs-generic-default")["count"] == 2
+
+                    res = self._es_client.search(index="logs-generic-default", sort="_seq_no")
+                    assert res["hits"]["total"] == {"value": 2, "relation": "eq"}
+                    assert (
+                        res["hits"]["hits"][1]["_source"]["fields"]["message"]
+                        == '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": "trigger"}'
+                    )
+                    assert res["hits"]["hits"][1]["_source"]["fields"]["log"] == {
+                        "offset": 0,
+                        "file": {"path": self._source_queue_info["QueueUrl"]},
+                    }
+                    assert res["hits"]["hits"][1]["_source"]["fields"]["aws"] == {
+                        "sqs": {
+                            "name": "source-queue",
+                            "message_id": message_id,
                         }
-                        assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
-                            "provider": "aws",
-                            "region": "us-east-1",
-                        }
+                    }
+                    assert res["hits"]["hits"][1]["_source"]["fields"]["cloud"] == {
+                        "provider": "aws",
+                        "region": "us-east-1",
+                    }
 
-                        assert res["hits"]["hits"][0]["_source"]["tags"] == [
-                            "preserve_original_event",
-                            "forwarded",
-                            "generic",
-                            "tag1",
-                            "tag2",
-                            "tag3",
-                        ]
-
-                        event = _event_from_sqs_message(queue_attributes=self._replay_queue_info)
-                        second_call = handler(event, ctx)  # type:ignore
-
-                        assert second_call == "replayed"
-
-                        self._es_client.indices.refresh(index="logs-generic-default")
-                        assert self._es_client.count(index="logs-generic-default")["count"] == 2
-
-                        res = self._es_client.search(index="logs-generic-default", sort="_seq_no")
-                        assert res["hits"]["total"] == {"value": 2, "relation": "eq"}
-                        assert (
-                            res["hits"]["hits"][1]["_source"]["fields"]["message"]
-                            == '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": "trigger"}'
-                        )
-                        assert res["hits"]["hits"][1]["_source"]["fields"]["log"] == {
-                            "offset": 0,
-                            "file": {"path": self._source_queue_info["QueueUrl"]},
-                        }
-                        assert res["hits"]["hits"][1]["_source"]["fields"]["aws"] == {
-                            "sqs": {
-                                "name": "source-queue",
-                                "message_id": message_id,
-                            }
-                        }
-                        assert res["hits"]["hits"][1]["_source"]["fields"]["cloud"] == {
-                            "provider": "aws",
-                            "region": "us-east-1",
-                        }
-
-                        assert res["hits"]["hits"][1]["_source"]["tags"] == [
-                            "preserve_original_event",
-                            "forwarded",
-                            "generic",
-                            "tag1",
-                            "tag2",
-                            "tag3",
-                        ]
+                    assert res["hits"]["hits"][1]["_source"]["tags"] == [
+                        "preserve_original_event",
+                        "forwarded",
+                        "generic",
+                        "tag1",
+                        "tag2",
+                        "tag3",
+                    ]
 
     def test_lambda_handler_continuing(self) -> None:
         with mock.patch("storage.S3Storage._s3_client", _mock_awsclient(service_name="s3")):
-            with mock.patch("handlers.aws.sqs_trigger.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
+            with mock.patch("handlers.aws.handler.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
                 with mock.patch("handlers.aws.utils.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
                     with mock.patch(
                         "share.secretsmanager._get_aws_sm_client",
@@ -1998,124 +2907,115 @@ class TestLambdaHandlerSuccessCloudWatchLogs(TestCase):
 
     def test_lambda_handler_continuing(self) -> None:
         with mock.patch("storage.S3Storage._s3_client", _mock_awsclient(service_name="s3")):
-            with mock.patch("handlers.aws.sqs_trigger.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
-                with mock.patch(
-                    "handlers.aws.utils.get_cloudwatch_logs_client", lambda: _mock_awsclient(service_name="logs")
-                ):
-                    with mock.patch(
-                        "handlers.aws.cloudwatch_logs_trigger.get_sqs_client",
-                        lambda: _mock_awsclient(service_name="sqs"),
-                    ):
+            with mock.patch(
+                "handlers.aws.utils.get_cloudwatch_logs_client", lambda: _mock_awsclient(service_name="logs")
+            ):
+                with mock.patch("handlers.aws.handler.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
+                    with mock.patch("handlers.aws.utils.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")):
                         with mock.patch(
-                            "handlers.aws.utils.get_sqs_client", lambda: _mock_awsclient(service_name="sqs")
+                            "share.secretsmanager._get_aws_sm_client",
+                            lambda region_name: _mock_awsclient(service_name="secretsmanager", region_name=region_name),
                         ):
-                            with mock.patch(
-                                "share.secretsmanager._get_aws_sm_client",
-                                lambda region_name: _mock_awsclient(
-                                    service_name="secretsmanager", region_name=region_name
-                                ),
-                            ):
+                            ctx = ContextMock()
 
-                                ctx = ContextMock()
+                            cloudwatch_log: str = (
+                                '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": '
+                                '"trigger"}\n{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": '
+                                '{"file": {"line": 30, "name": "handler.py"}, "function": "lambda_handler"}, '
+                                '"original": "trigger"}}\n'
+                            )
 
-                                cloudwatch_log: str = (
-                                    '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": '
-                                    '"trigger"}\n{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": '
-                                    '{"file": {"line": 30, "name": "handler.py"}, "function": "lambda_handler"}, '
-                                    '"original": "trigger"}}\n'
-                                )
+                            _event_to_cloudwatch_logs(
+                                group_name="source-group", stream_name="source-stream", message_body=cloudwatch_log
+                            )
 
-                                self._event_to_cloudwatch_logs(
-                                    group_name="source-group", stream_name="source-stream", message_body=cloudwatch_log
-                                )
+                            event, event_id = _event_from_cloudwatch_logs(
+                                group_name="source-group", stream_name="source-stream"
+                            )
 
-                                event, event_id = self._event_from_cloudwatch_logs(
-                                    group_name="source-group", stream_name="source-stream"
-                                )
+                            first_call = handler(event, ctx)  # type:ignore
 
-                                first_call = handler(event, ctx)  # type:ignore
+                            assert first_call == "continuing"
 
-                                assert first_call == "continuing"
+                            self._es_client.indices.refresh(index="logs-generic-default")
+                            assert self._es_client.count(index="logs-generic-default")["count"] == 1
 
-                                self._es_client.indices.refresh(index="logs-generic-default")
-                                assert self._es_client.count(index="logs-generic-default")["count"] == 1
-
-                                res = self._es_client.search(index="logs-generic-default", sort="_seq_no")
-                                assert res["hits"]["total"] == {"value": 1, "relation": "eq"}
-                                assert (
-                                    res["hits"]["hits"][0]["_source"]["fields"]["message"]
-                                    == '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": '
-                                    '"trigger"}'
-                                )
-                                assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
-                                    "offset": 0,
-                                    "file": {"path": "source-group/source-stream"},
+                            res = self._es_client.search(index="logs-generic-default", sort="_seq_no")
+                            assert res["hits"]["total"] == {"value": 1, "relation": "eq"}
+                            assert (
+                                res["hits"]["hits"][0]["_source"]["fields"]["message"]
+                                == '{"@timestamp": "2021-12-28T11:33:08.160Z", "log.level": "info", "message": '
+                                '"trigger"}'
+                            )
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["log"] == {
+                                "offset": 0,
+                                "file": {"path": "source-group/source-stream"},
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
+                                "cloudwatch_logs": {
+                                    "group_name": "source-group",
+                                    "stream_name": "source-stream",
+                                    "event_id": event_id,
                                 }
-                                assert res["hits"]["hits"][0]["_source"]["fields"]["aws"] == {
-                                    "cloudwatch_logs": {
-                                        "group_name": "source-group",
-                                        "stream_name": "source-stream",
-                                        "event_id": event_id,
-                                    }
+                            }
+                            assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
+                                "provider": "aws",
+                                "region": "us-east-1",
+                            }
+
+                            assert res["hits"]["hits"][0]["_source"]["tags"] == [
+                                "preserve_original_event",
+                                "forwarded",
+                                "generic",
+                                "tag1",
+                                "tag2",
+                                "tag3",
+                            ]
+
+                            event = _event_from_sqs_message(queue_attributes=self._continuing_queue_info)
+                            second_call = handler(event, ctx)  # type:ignore
+
+                            assert second_call == "continuing"
+
+                            self._es_client.indices.refresh(index="logs-generic-default")
+                            assert self._es_client.count(index="logs-generic-default")["count"] == 2
+
+                            res = self._es_client.search(index="logs-generic-default", sort="_seq_no")
+                            assert res["hits"]["total"] == {"value": 2, "relation": "eq"}
+
+                            assert (
+                                res["hits"]["hits"][1]["_source"]["fields"]["message"]
+                                == '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": '
+                                '{"line": 30, "name": "handler.py"}, "function": "lambda_handler"}, '
+                                '"original": "trigger"}}'
+                            )
+
+                            assert res["hits"]["hits"][1]["_source"]["fields"]["log"] == {
+                                "offset": 86,
+                                "file": {"path": "source-group/source-stream"},
+                            }
+                            assert res["hits"]["hits"][1]["_source"]["fields"]["aws"] == {
+                                "cloudwatch_logs": {
+                                    "group_name": "source-group",
+                                    "stream_name": "source-stream",
+                                    "event_id": event_id,
                                 }
-                                assert res["hits"]["hits"][0]["_source"]["fields"]["cloud"] == {
-                                    "provider": "aws",
-                                    "region": "us-east-1",
-                                }
+                            }
+                            assert res["hits"]["hits"][1]["_source"]["fields"]["cloud"] == {
+                                "provider": "aws",
+                                "region": "us-east-1",
+                            }
 
-                                assert res["hits"]["hits"][0]["_source"]["tags"] == [
-                                    "preserve_original_event",
-                                    "forwarded",
-                                    "generic",
-                                    "tag1",
-                                    "tag2",
-                                    "tag3",
-                                ]
+                            assert res["hits"]["hits"][1]["_source"]["tags"] == [
+                                "preserve_original_event",
+                                "forwarded",
+                                "generic",
+                                "tag1",
+                                "tag2",
+                                "tag3",
+                            ]
 
-                                event = _event_from_sqs_message(queue_attributes=self._continuing_queue_info)
-                                second_call = handler(event, ctx)  # type:ignore
+                            event = _event_from_sqs_message(queue_attributes=self._continuing_queue_info)
+                            third_call = handler(event, ctx)  # type:ignore
 
-                                assert second_call == "continuing"
-
-                                self._es_client.indices.refresh(index="logs-generic-default")
-                                assert self._es_client.count(index="logs-generic-default")["count"] == 2
-
-                                res = self._es_client.search(index="logs-generic-default", sort="_seq_no")
-                                assert res["hits"]["total"] == {"value": 2, "relation": "eq"}
-
-                                assert (
-                                    res["hits"]["hits"][1]["_source"]["fields"]["message"]
-                                    == '{"ecs": {"version": "1.6.0"}, "log": {"logger": "root", "origin": {"file": '
-                                    '{"line": 30, "name": "handler.py"}, "function": "lambda_handler"}, '
-                                    '"original": "trigger"}}'
-                                )
-
-                                assert res["hits"]["hits"][1]["_source"]["fields"]["log"] == {
-                                    "offset": 86,
-                                    "file": {"path": "source-group/source-stream"},
-                                }
-                                assert res["hits"]["hits"][1]["_source"]["fields"]["aws"] == {
-                                    "cloudwatch_logs": {
-                                        "group_name": "source-group",
-                                        "stream_name": "source-stream",
-                                        "event_id": event_id,
-                                    }
-                                }
-                                assert res["hits"]["hits"][1]["_source"]["fields"]["cloud"] == {
-                                    "provider": "aws",
-                                    "region": "us-east-1",
-                                }
-
-                                assert res["hits"]["hits"][1]["_source"]["tags"] == [
-                                    "preserve_original_event",
-                                    "forwarded",
-                                    "generic",
-                                    "tag1",
-                                    "tag2",
-                                    "tag3",
-                                ]
-
-                                event = _event_from_sqs_message(queue_attributes=self._continuing_queue_info)
-                                third_call = handler(event, ctx)  # type:ignore
-
-                                assert third_call == "completed"
+                            assert third_call == "completed"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
Enhancement
## What does this PR do?
Fix handling of batch messages in the continuing queue where the original event sources are different for every message when the batch size is greater than 1

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
The continuing queue receive messages from different original inputs: `cloudwatch-logs`, `sqs`, `s3-sqs`
When we started the development this complexity was not taken in consideration, and the type and id of the input from the first record of the queue was used. While this behaviour is reliable for user provided event inputs it breaks the correctness of the processing when applied to the continuing queue, where the same batch can contains messages with different original inputs.
This also allows the default batch size of the event source mapping for the continuing queue to be set to 10

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
