### PR TITLE
Simplify the Shipper base class type 

### DIFF
--- a/handlers/aws/replay_trigger.py
+++ b/handlers/aws/replay_trigger.py
@@ -5,7 +5,7 @@
 from typing import Any, Optional
 
 from share import Config, ElasticsearchOutput, Input, Output, shared_logger
-from shippers import ElasticsearchShipper, ShipperFactory
+from shippers import ShipperFactory
 
 from .exceptions import InputConfigException, OutputConfigException, ReplayHandlerException
 from .utils import delete_sqs_record
@@ -56,7 +56,7 @@ def _handle_replay_event(
         assert isinstance(output, ElasticsearchOutput)
         output.es_datastream_name = output_args["es_datastream_name"]
         shared_logger.info("setting ElasticSearch shipper")
-        elasticsearch: ElasticsearchShipper = ShipperFactory.create_from_output(output_type=output_type, output=output)
+        elasticsearch = ShipperFactory.create_from_output(output_type=output_type, output=output)
         elasticsearch.set_replay_handler(replay_handler=replay_handler.replay_handler)
         elasticsearch.send(event_payload)
         elasticsearch.flush()

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -14,7 +14,7 @@ from elasticapm import get_client as get_apm_client
 from elasticapm.contrib.serverless.aws import capture_serverless as apm_capture_serverless  # noqa: F401
 
 from share import Input, Output, json_dumper, json_parser, shared_logger
-from shippers import CompositeShipper, ElasticsearchShipper, ShipperFactory
+from shippers import CompositeShipper, ShipperFactory
 from storage import ProtocolStorage, StorageFactory
 
 from .exceptions import (
@@ -162,9 +162,7 @@ def get_shipper_from_input(
             output: Optional[Output] = event_input.get_output_by_type("elasticsearch")
             assert output is not None
 
-            shipper: ElasticsearchShipper = ShipperFactory.create_from_output(
-                output_type="elasticsearch", output=output
-            )
+            shipper = ShipperFactory.create_from_output(output_type="elasticsearch", output=output)
             composite_shipper.add_shipper(shipper=shipper)
             composite_shipper.set_integration_scope(integration_scope=integration_scope)
             replay_handler = ReplayEventHandler(config_yaml=config_yaml, event_input=event_input)

--- a/shippers/__init__.py
+++ b/shippers/__init__.py
@@ -11,6 +11,5 @@ from .shipper import (
     EVENT_IS_SENT,
     EventIdGeneratorCallable,
     ProtocolShipper,
-    ProtocolShipperType,
     ReplayHandlerCallable,
 )

--- a/shippers/es.py
+++ b/shippers/es.py
@@ -12,7 +12,7 @@ from elasticsearch.serializer import Serializer
 
 from share import json_dumper, json_parser, shared_logger
 
-from .shipper import EventIdGeneratorCallable, ReplayHandlerCallable
+from .shipper import EventIdGeneratorCallable, ProtocolShipper, ReplayHandlerCallable
 
 _EVENT_BUFFERED = "_EVENT_BUFFERED"
 _EVENT_SENT = "_EVENT_SENT"
@@ -40,7 +40,7 @@ class JSONSerializer(Serializer):
             raise SerializationError(data, e)
 
 
-class ElasticsearchShipper:
+class ElasticsearchShipper(ProtocolShipper):
     """
     Elasticsearch Shipper.
     This class implements concrete Elasticsearch Shipper

--- a/shippers/factory.py
+++ b/shippers/factory.py
@@ -2,17 +2,15 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-from typing import Any, Callable
+from typing import Any, Type
 
 from share.config import ElasticsearchOutput, Output
 
 from .es import ElasticsearchShipper
-from .shipper import ProtocolShipperType
+from .shipper import ProtocolShipper
 
-_init_definition_by_output: dict[str, dict[str, Any]] = {
-    "elasticsearch": {
-        "class": ElasticsearchShipper,
-    }
+_shippers: dict[str, Type[ProtocolShipper]] = {
+    "elasticsearch": ElasticsearchShipper,
 }
 
 
@@ -23,7 +21,7 @@ class ShipperFactory:
     """
 
     @staticmethod
-    def create_from_output(output_type: str, output: Output) -> ProtocolShipperType:
+    def create_from_output(output_type: str, output: Output) -> ProtocolShipper:
         """
         Instantiates a concrete Shipper given an output type and an Output instance
         """
@@ -46,22 +44,18 @@ class ShipperFactory:
             )
 
         raise ValueError(
-            f"You must provide one of the following outputs: " f"{', '.join(_init_definition_by_output.keys())}"
+            f"You must provide one of the following outputs: " f"{', '.join(_shippers.keys())}"
         )
 
     @staticmethod
-    def create(output_type: str, **kwargs: Any) -> ProtocolShipperType:
+    def create(output_type: str, **kwargs: Any) -> ProtocolShipper:
         """
         Instantiates a concrete Shipper given an output type and the shipper init kwargs
         """
 
-        if output_type not in _init_definition_by_output:
+        if output_type not in _shippers:
             raise ValueError(
-                f"You must provide one of the following outputs: " f"{', '.join(_init_definition_by_output.keys())}"
+                f"You must provide one of the following outputs: " f"{', '.join(_shippers.keys())}"
             )
 
-        output_definition = _init_definition_by_output[output_type]
-
-        output_builder: Callable[..., ProtocolShipperType] = output_definition["class"]
-
-        return output_builder(**kwargs)
+        return _shippers[output_type](**kwargs)

--- a/shippers/factory.py
+++ b/shippers/factory.py
@@ -43,9 +43,7 @@ class ShipperFactory:
                 batch_max_bytes=output.batch_max_bytes,
             )
 
-        raise ValueError(
-            f"You must provide one of the following outputs: " f"{', '.join(_shippers.keys())}"
-        )
+        raise ValueError(f"You must provide one of the following outputs: " f"{', '.join(_shippers.keys())}")
 
     @staticmethod
     def create(output_type: str, **kwargs: Any) -> ProtocolShipper:
@@ -54,8 +52,6 @@ class ShipperFactory:
         """
 
         if output_type not in _shippers:
-            raise ValueError(
-                f"You must provide one of the following outputs: " f"{', '.join(_shippers.keys())}"
-            )
+            raise ValueError(f"You must provide one of the following outputs: " f"{', '.join(_shippers.keys())}")
 
         return _shippers[output_type](**kwargs)

--- a/shippers/shipper.py
+++ b/shippers/shipper.py
@@ -2,7 +2,8 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-from typing import Any, Callable, Protocol, TypeVar
+from abc import abstractmethod
+from typing import Any, Callable, Protocol
 
 ReplayHandlerCallable = Callable[[str, dict[str, Any], dict[str, Any]], None]
 EventIdGeneratorCallable = Callable[[dict[str, Any]], str]
@@ -16,18 +17,19 @@ class ProtocolShipper(Protocol):
     """
     Protocol for Shipper components
     """
-
+    
+    @abstractmethod
     def send(self, event: dict[str, Any]) -> str:
         pass  # pragma: no cover
 
+    @abstractmethod
     def set_event_id_generator(self, event_id_generator: EventIdGeneratorCallable) -> None:
         pass  # pragma: no cover
 
+    @abstractmethod
     def set_replay_handler(self, replay_handler: ReplayHandlerCallable) -> None:
         pass  # pragma: no cover
 
+    @abstractmethod
     def flush(self) -> None:
         pass  # pragma: no cover
-
-
-ProtocolShipperType = TypeVar("ProtocolShipperType", bound=ProtocolShipper)

--- a/shippers/shipper.py
+++ b/shippers/shipper.py
@@ -17,7 +17,7 @@ class ProtocolShipper(Protocol):
     """
     Protocol for Shipper components
     """
-    
+
     @abstractmethod
     def send(self, event: dict[str, Any]) -> str:
         pass  # pragma: no cover


### PR DESCRIPTION
The ProtocolShipperType was causing some confusion in our static type checking (mypy). Removing it and just using ProtocolShipper as the return type of the shipper factory simplifies this. Explicitly subclassing the ABC ('ProtocolShipper'), also guarantees a runtime check that the shipper class implements the required ABC methods.

The only downside of this approach is that we cannot write this code:

```
elasticsearch_shipper: ElasticsearchShipper = create_from_output('elasticsearch', ...)
```

This seems totally reasonable - sure, the factory returns different types depending on its inputs, but I think its better for callers not to assume which concrete type, and just use the ABC methods only.