### PR TITLE
[Logstash] Retry and Replay queue handling

### DIFF
--- a/handlers/aws/replay_trigger.py
+++ b/handlers/aws/replay_trigger.py
@@ -5,6 +5,7 @@
 from typing import Any, Optional
 
 from share import Config, ElasticsearchOutput, Input, Output, shared_logger
+from share.config import LogstashOutput
 from shippers import ProtocolShipper, ShipperFactory
 
 from .exceptions import InputConfigException, OutputConfigException, ReplayHandlerException
@@ -57,5 +58,13 @@ def get_shipper_for_replay_event(
         elasticsearch.set_replay_handler(replay_handler=replay_handler.replay_handler)
 
         return elasticsearch
+
+    if output_type == "logstash":
+        assert isinstance(output, LogstashOutput)
+        shared_logger.info("setting Logstash shipper")
+        logstash: ProtocolShipper = ShipperFactory.create_from_output(output_type=output_type, output=output)
+        logstash.set_replay_handler(replay_handler=replay_handler.replay_handler)
+
+        return logstash
 
     return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ elasticsearch>=7.16,<7.17
 PyYAML>=6.0,<6.1
 aws_lambda_typing>=2.16.1,<3
 ujson>=5.5.0,<5.6
-requests>=2.25.1
-
+requests<2.26,>=2.20.0
+responses>=0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ elasticsearch>=7.16,<7.17
 PyYAML>=6.0,<6.1
 aws_lambda_typing>=2.16.1,<3
 ujson>=5.5.0,<5.6
-requests<2.26,>=2.20.0
+requests==2.25.1
 responses>=0.22.0

--- a/shippers/logstash.py
+++ b/shippers/logstash.py
@@ -53,6 +53,9 @@ class LogstashShipper:
         self._session.mount(self._logstash_url, HTTPAdapter(max_retries=retry_strategy))
 
     def send(self, event: dict[str, Any]) -> str:
+        if "_id" not in event and self._event_id_generator is not None:
+            event["_id"] = self._event_id_generator(event)
+
         self._events_batch.append(event)
         if len(self._events_batch) < self._max_batch_size:
             return _EVENT_BUFFERED
@@ -86,4 +89,4 @@ class LogstashShipper:
             )
             if self._replay_handler is not None:
                 for event in events:
-                    self._replay_handler("logstash shipper", self._replay_args, event)
+                    self._replay_handler("logstash", self._replay_args, event)

--- a/shippers/logstash.py
+++ b/shippers/logstash.py
@@ -7,11 +7,23 @@ from typing import Any, Optional
 
 import requests
 import ujson
+from requests.adapters import HTTPAdapter
+from requests.exceptions import RequestException
+from urllib3.util.retry import Retry
 
+from share import shared_logger
 from shippers.shipper import EventIdGeneratorCallable, ReplayHandlerCallable
 
 _EVENT_SENT = "_EVENT_SENT"
 _EVENT_BUFFERED = "_EVENT_BUFFERED"
+
+_TIMEOUT = 10
+_MAX_RETRIES = 4
+_STATUS_FORCE_LIST = [429, 500, 502, 503, 504]
+# A backoff factor to apply between attempts after the second try. urllib3 will sleep for:
+# {backoff factor} * (2 ** ({number of total retries} - 1))
+# seconds. If the backoff_factor is 1, then sleep() will sleep for [0s, 2s, 4s, …] between retries.
+_BACKOFF_FACTOR = 1
 
 
 class LogstashShipper:
@@ -34,7 +46,11 @@ class LogstashShipper:
             self._compression_level = compression_level
         else:
             raise ValueError("compression_level must be an integer value between 0 and 9")
+        self._replay_args: dict[str, Any] = {}
+
         self._session = requests.Session()
+        retry_strategy = Retry(total=_MAX_RETRIES, backoff_factor=_BACKOFF_FACTOR, status_forcelist=_STATUS_FORCE_LIST)
+        self._session.mount(self._logstash_url, HTTPAdapter(max_retries=retry_strategy))
 
     def send(self, event: dict[str, Any]) -> str:
         self._events_batch.append(event)
@@ -57,11 +73,17 @@ class LogstashShipper:
 
     def _send(self, logstash_url: str, events: list[dict[str, Any]], compression_level: int) -> None:
         ndjson = "\n".join(ujson.dumps(event) for event in events)
-        response = self._session.put(
-            logstash_url,
-            data=gzip.compress(ndjson.encode("utf-8"), compression_level),
-            headers={"Content-Encoding": "gzip", "Content-Type": "application/x-ndjson"},
-        )
-        if response.status_code != 200:
-            # TODO: Change with actual handling
-            raise RuntimeError(f"Errors while sending data to Logstash. Return code {response.status_code}")
+        try:
+            self._session.put(
+                logstash_url,
+                data=gzip.compress(ndjson.encode("utf-8"), compression_level),
+                headers={"Content-Encoding": "gzip", "Content-Type": "application/x-ndjson"},
+                timeout=_TIMEOUT,
+            )
+        except RequestException as e:
+            shared_logger.error(
+                f"logstash shipper encountered an error while publishing events to logstash. Error: {str(e)}"
+            )
+            if self._replay_handler is not None:
+                for event in events:
+                    self._replay_handler("logstash shipper", self._replay_args, event)

--- a/tests/handlers/aws/test_replay_trigger.py
+++ b/tests/handlers/aws/test_replay_trigger.py
@@ -1,0 +1,36 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+from unittest import TestCase
+
+import pytest
+
+from handlers.aws.replay_trigger import ReplayedEventReplayHandler, get_shipper_for_replay_event
+from share import parse_config
+from shippers.logstash import LogstashShipper
+
+
+@pytest.mark.unit
+class TestReplayTrigger(TestCase):
+    def test_get_shipper_for_replay_event(self) -> None:
+        with self.subTest("Logstash shipper from replay event"):
+            config_yaml_kinesis: str = """
+                                inputs:
+                                  - type: kinesis-data-stream
+                                    id: arn:aws:kinesis:eu-central-1:123456789:stream/test-esf-kinesis-stream
+                                    outputs:
+                                        - type: logstash
+                                          args:
+                                            logstash_url: logstash_url
+                            """
+            config = parse_config(config_yaml_kinesis)
+            replay_handler = ReplayedEventReplayHandler("arn:aws:sqs:eu-central-1:123456789:queue/replayqueue")
+            logstash_shipper = get_shipper_for_replay_event(
+                config,
+                "logstash",
+                {},
+                "arn:aws:kinesis:eu-central-1:123456789:stream/test-esf-kinesis-stream",
+                replay_handler,
+            )
+            assert isinstance(logstash_shipper, LogstashShipper)

--- a/tests/shippers/test_logstash.py
+++ b/tests/shippers/test_logstash.py
@@ -3,12 +3,16 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 
 import datetime
+import gzip
 from typing import Any
-from unittest import TestCase, mock
+from unittest import TestCase
 
 import pytest
+import responses
+import ujson
+from requests import PreparedRequest
 
-from shippers.logstash import _EVENT_SENT, LogstashShipper
+from shippers.logstash import _EVENT_SENT, _MAX_RETRIES, LogstashShipper
 
 _now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
@@ -42,31 +46,66 @@ _dummy_event: dict[str, Any] = {
 }
 
 
-class MockResponse:
-    def __init__(self, status_code: int):
-        self.status_code = status_code
-
-
-_200_OK = mock.MagicMock(return_value=MockResponse(200))
-_429_TOO_MANY_REQUESTS = mock.MagicMock(return_value=MockResponse(429))
+def _dummy_replay_handler(output_type: str, output_args: dict[str, Any], event_payload: dict[str, Any]) -> None:
+    assert output_type == "logstash shipper"
+    assert event_payload == _dummy_event
 
 
 @pytest.mark.unit
 class TestLogstashShipper(TestCase):
-    @mock.patch("shippers.logstash.requests.Session.put", _200_OK)
+    @responses.activate
     def test_send_successful(self) -> None:
-        logstash_shipper = LogstashShipper(logstash_url="http://logstash_url")
-        assert logstash_shipper.send(_dummy_event) == _EVENT_SENT
+        def request_callback(request: PreparedRequest) -> tuple[int, dict[Any, Any], str]:
+            _payload = []
+            assert request.headers["Content-Encoding"] == "gzip"
+            assert request.headers["Content-Type"] == "application/x-ndjson"
+            assert request.body is not None
+            assert isinstance(request.body, bytes)
 
-    @mock.patch("shippers.logstash.requests.Session.put", _429_TOO_MANY_REQUESTS)
-    def test_send_too_many_requests(self) -> None:
-        logstash_shipper = LogstashShipper(logstash_url="http://logstash_url")
-        with self.assertRaisesRegex(RuntimeError, "Errors while sending data to Logstash. Return code 429"):
-            logstash_shipper.send(_dummy_event)
+            events = gzip.decompress(request.body).decode("utf-8").split("\n")
+            for event in events:
+                _payload.append(ujson.loads(event))
 
-    @mock.patch("shippers.logstash.requests.Session.put", _200_OK)
+            assert _payload == [_dummy_event, _dummy_event]
+
+            return 200, {}, "okay"
+
+        url = "http://logstash_url"
+        responses.add_callback(responses.PUT, url, callback=request_callback)
+        logstash_shipper = LogstashShipper(logstash_url=url, max_batch_size=2)
+        logstash_shipper.send(_dummy_event)
+        logstash_shipper.send(_dummy_event)
+
+    @responses.activate
+    def test_send_failures(self) -> None:
+        url = "http://logstash_url"
+        with self.subTest("Does not exceed max_retries"):
+            responses.put(url=url, status=429)
+            responses.put(url=url, status=429)
+            responses.put(url=url, status=429)
+            responses.put(url=url, status=200)
+            logstash_shipper = LogstashShipper(logstash_url=url)
+            assert logstash_shipper.send(_dummy_event) == _EVENT_SENT
+        with self.subTest("Exceeds max retries, replay handler set"):
+            for i in range(_MAX_RETRIES):
+                responses.put(url=url, status=429)
+            responses.put(url=url, status=429)
+            logstash_shipper = LogstashShipper(logstash_url=url)
+            logstash_shipper.set_replay_handler(_dummy_replay_handler)
+            assert logstash_shipper.send(_dummy_event) == _EVENT_SENT
+        with self.subTest("Exceeds max retries, replay handler not set"):
+            for i in range(_MAX_RETRIES):
+                responses.put(url=url, status=429)
+            responses.put(url=url, status=429)
+            logstash_shipper = LogstashShipper(logstash_url=url)
+            assert logstash_shipper.send(_dummy_event) == _EVENT_SENT
+
+    @responses.activate
     def test_flush(self) -> None:
-        logstash_shipper = LogstashShipper(logstash_url="http://logstash_url", max_batch_size=2)
+        url = "http://logstash_url"
+        responses.put(url=url, status=200)
+        responses.put(url=url, status=200)
+        logstash_shipper = LogstashShipper(logstash_url=url, max_batch_size=2)
         logstash_shipper.send(_dummy_event)
         assert logstash_shipper._events_batch == [_dummy_event]
         logstash_shipper.flush()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR does the following:
- Adds Retry+Exponential backoff logic for the logstash shipper, leveraging `urllib3.util.retry`
- Adds basic logic to send failed events to the replay queue, if the maximum number of retries is exceeded. Since we cannot know which events failed to be processed by Logstash, the whole batch of events is sent to the replay queue.
- Adds "_id" to the event forwarded by the Logstash shipper, similarly to what done in the ElasticSearch shipper. 
    - _NOTE: This is not stricly required by Logstash, but was added to simplify the implementation, since the replay queue handler that is currently present, assumes that the event includes `_id`_
- Improves unit tests for the Logstash shipper, using `responses`


