### PR TITLE
Changed ID generation logic to use AWS-provided ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.6.0 - 2023/01/25
+##### Features
+* Changed ID generation logic to use AWS-provided ids: [#214](https://github.com/elastic/elastic-serverless-forwarder/pull/214)
+
 ### v1.5.0 - 2022/10/20
 ##### Features
 * Allow to connect to ES with self-signed certificate through certificate fingerprint assertion: [#173](https://github.com/elastic/elastic-serverless-forwarder/pull/173)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Elastic Serverless Forwarder
 
 ## Important - v1.6.0
 
-#### Version 1.6.0 introduces a new event ID format which is backwards incompatible with previously indexed events. Be aware that previously indexed events would be duplicated if they triggered the forwarder again after upgrading to this version. More information is available at [our troubleshooting documentation](https://www.elastic.co/guide/en/observability/master/aws-serverless-troubleshooting.html).
+#### Version 1.6.0 introduces a new event ID format which is backwards incompatible with previously indexed events. Be aware that previously indexed events would be duplicated if they trigger the forwarder again after upgrading to this version. More information is available at [our troubleshooting documentation](https://www.elastic.co/guide/en/observability/master/aws-serverless-troubleshooting.html).
 
 ### Changelog [link](https://github.com/elastic/elastic-serverless-forwarder/blob/main/CHANGELOG.md)
 ### For AWS documentation, [go here](https://github.com/elastic/elastic-serverless-forwarder/blob/main/docs/README-AWS.md)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Elastic Serverless Forwarder
 
 ## Important - v1.6.0
 
-#### Version 1.6.0 introduces a new way to generate event IDs. More information is available at [our troubleshooting documentation](https://www.elastic.co/guide/en/observability/master/aws-serverless-troubleshooting.html).
+#### Version 1.6.0 introduces a new event ID format which is backwards incompatible with previously indexed events. Be aware that previously indexed events would be duplicated if they triggered the forwarder again after upgrading to this version. More information is available at [our troubleshooting documentation](https://www.elastic.co/guide/en/observability/master/aws-serverless-troubleshooting.html).
 
 ### Changelog [link](https://github.com/elastic/elastic-serverless-forwarder/blob/main/CHANGELOG.md)
 ### For AWS documentation, [go here](https://github.com/elastic/elastic-serverless-forwarder/blob/main/docs/README-AWS.md)

--- a/README.md
+++ b/README.md
@@ -3,5 +3,9 @@
 # elastic-serverless-forwarder
 Elastic Serverless Forwarder
 
+## Important - v1.6.0
 
+#### Version 1.6.0 introduces a new way to generate event IDs. More information is available at [our troubleshooting documentation](https://www.elastic.co/guide/en/observability/master/aws-serverless-troubleshooting.html).
+
+### Changelog [link](https://github.com/elastic/elastic-serverless-forwarder/blob/main/CHANGELOG.md)
 ### For AWS documentation, [go here](https://github.com/elastic/elastic-serverless-forwarder/blob/main/docs/README-AWS.md)

--- a/README.md
+++ b/README.md
@@ -3,9 +3,5 @@
 # elastic-serverless-forwarder
 Elastic Serverless Forwarder
 
-## Important - v1.6.0
-
-#### Version 1.6.0 introduces a new event ID format which is backwards incompatible with previously indexed events. Be aware that previously indexed events would be duplicated if they trigger the forwarder again after upgrading to this version. More information is available at [our troubleshooting documentation](https://www.elastic.co/guide/en/observability/master/aws-serverless-troubleshooting.html).
-
 ### Changelog [link](https://github.com/elastic/elastic-serverless-forwarder/blob/main/CHANGELOG.md)
 ### For AWS documentation, [go here](https://github.com/elastic/elastic-serverless-forwarder/blob/main/docs/README-AWS.md)

--- a/docs/README-AWS.md
+++ b/docs/README-AWS.md
@@ -15,7 +15,7 @@ Please refer to the official [Elastic documentation for Elastic Serverless Forwa
 
 ## Important - v1.6.0
 
-#### Version 1.6.0 introduces a new event ID format which is backwards incompatible with previously indexed events. Be aware that previously indexed events would be duplicated if they trigger the forwarder again after upgrading to this version. More information is available at [our troubleshooting documentation](https://www.elastic.co/guide/en/observability/master/aws-serverless-troubleshooting.html).
+#### Version 1.6.0 introduces a new event ID format which is backwards incompatible with previously indexed events. Be aware that previously indexed events would be duplicated if they trigger the forwarder again after upgrading to this version. More information is available at [our troubleshooting documentation](https://www.elastic.co/guide/en/observability/master/aws-serverless-troubleshooting.html#aws-serverless-troubleshooting-1.6.0-id-changes).
 
 ## Resources and links
 

--- a/docs/README-AWS.md
+++ b/docs/README-AWS.md
@@ -13,6 +13,10 @@ Please refer to the official [Elastic documentation for Elastic Serverless Forwa
 
 ![Lambda flow](https://github.com/elastic/elastic-serverless-forwarder/raw/lambda-v0.25.0/docs/lambda-flow.png)
 
+## Important - v1.6.0
+
+#### Version 1.6.0 introduces a new event ID format which is backwards incompatible with previously indexed events. Be aware that previously indexed events would be duplicated if they trigger the forwarder again after upgrading to this version. More information is available at [our troubleshooting documentation](https://www.elastic.co/guide/en/observability/master/aws-serverless-troubleshooting.html).
+
 ## Resources and links
 
 * [Elastic documentation for Elastic Serverless Forwarder](https://www.elastic.co/guide/en/observability/master/aws-elastic-serverless-forwarder.html)

--- a/handlers/aws/cloudwatch_logs_trigger.py
+++ b/handlers/aws/cloudwatch_logs_trigger.py
@@ -54,6 +54,7 @@ def _handle_cloudwatch_logs_continuation(
             "originalEventSourceARN": {"StringValue": event_input_id, "DataType": "String"},
             "originalLogGroup": {"StringValue": log_group_name, "DataType": "String"},
             "originalLogStream": {"StringValue": log_stream_name, "DataType": "String"},
+            "originalEventTimestamp": {"StringValue": str(log_event["timestamp"]), "DataType": "Number"},
         }
 
         if last_ending_offset is not None:
@@ -81,6 +82,7 @@ def _handle_cloudwatch_logs_continuation(
                 "last_ending_offset": last_ending_offset,
                 "last_event_expanded_offset": last_event_expanded_offset,
                 "event_id": log_event["id"],
+                "event_timestamp": log_event["timestamp"],
             },
         )
 
@@ -108,6 +110,7 @@ def _handle_cloudwatch_logs_event(
 
     for cloudwatch_log_event_n, cloudwatch_log_event in enumerate(event["logEvents"]):
         event_id = cloudwatch_log_event["id"]
+        event_timestamp = cloudwatch_log_event["timestamp"]
 
         storage_message: ProtocolStorage = StorageFactory.create(
             storage_type="payload",
@@ -145,7 +148,7 @@ def _handle_cloudwatch_logs_event(
                         "account": {"id": account_id},
                     },
                 },
-                "meta": {},
+                "meta": {"event_timestamp": event_timestamp},
             }
 
             yield es_event, ending_offset, event_expanded_offset, cloudwatch_log_event_n

--- a/handlers/aws/kinesis_trigger.py
+++ b/handlers/aws/kinesis_trigger.py
@@ -32,6 +32,7 @@ def _handle_kinesis_continuation(
 
     sequence_number = kinesis_record["kinesis"]["sequenceNumber"]
     partition_key = kinesis_record["kinesis"]["partitionKey"]
+    approximate_arrival_timestamp = kinesis_record["kinesis"]["approximateArrivalTimestamp"]
     stream_type, stream_name, _ = get_kinesis_stream_name_type_and_region_from_arn(event_input_id)
 
     message_attributes = {
@@ -41,6 +42,10 @@ def _handle_kinesis_continuation(
         "originalPartitionKey": {"StringValue": partition_key, "DataType": "String"},
         "originalSequenceNumber": {"StringValue": sequence_number, "DataType": "String"},
         "originalEventSourceARN": {"StringValue": event_input_id, "DataType": "String"},
+        "originalApproximateArrivalTimestamp": {
+            "StringValue": str(approximate_arrival_timestamp),
+            "DataType": "Number",
+        },
     }
 
     if last_ending_offset is not None:
@@ -67,6 +72,8 @@ def _handle_kinesis_continuation(
             "sqs_continuing_queue": sqs_continuing_queue,
             "last_ending_offset": last_ending_offset,
             "last_event_expanded_offset": last_event_expanded_offset,
+            "partition_key": partition_key,
+            "approximate_arrival_timestamp": approximate_arrival_timestamp,
             "sequence_number": sequence_number,
         },
     )
@@ -85,7 +92,6 @@ def _handle_kinesis_record(
     the content of kinesis.data payload
     """
     account_id = get_account_id_from_arn(input_id)
-
     for kinesis_record_n, kinesis_record in enumerate(event["Records"]):
         storage: ProtocolStorage = StorageFactory.create(
             storage_type="payload",
@@ -122,6 +128,9 @@ def _handle_kinesis_record(
                             "name": stream_name,
                             "partition_key": kinesis_record["kinesis"]["partitionKey"],
                             "sequence_number": kinesis_record["kinesis"]["sequenceNumber"],
+                            "approximate_arrival_timestamp": int(
+                                kinesis_record["kinesis"]["approximateArrivalTimestamp"]
+                            ),
                         }
                     },
                     "cloud": {

--- a/handlers/aws/kinesis_trigger.py
+++ b/handlers/aws/kinesis_trigger.py
@@ -87,7 +87,6 @@ def _handle_kinesis_record(
     account_id = get_account_id_from_arn(input_id)
 
     for kinesis_record_n, kinesis_record in enumerate(event["Records"]):
-        shared_logger.info(kinesis_record)
         storage: ProtocolStorage = StorageFactory.create(
             storage_type="payload",
             payload=kinesis_record["kinesis"]["data"],

--- a/handlers/aws/kinesis_trigger.py
+++ b/handlers/aws/kinesis_trigger.py
@@ -128,9 +128,6 @@ def _handle_kinesis_record(
                             "name": stream_name,
                             "partition_key": kinesis_record["kinesis"]["partitionKey"],
                             "sequence_number": kinesis_record["kinesis"]["sequenceNumber"],
-                            "approximate_arrival_timestamp": int(
-                                kinesis_record["kinesis"]["approximateArrivalTimestamp"]
-                            ),
                         }
                     },
                     "cloud": {
@@ -139,7 +136,11 @@ def _handle_kinesis_record(
                         "account": {"id": account_id},
                     },
                 },
-                "meta": {},
+                "meta": {
+                    "approximate_arrival_timestamp": int(
+                        float(kinesis_record["kinesis"]["approximateArrivalTimestamp"]) * 1000
+                    ),
+                },
             }
 
             yield es_event, ending_offset, event_expanded_offset, kinesis_record_n

--- a/handlers/aws/kinesis_trigger.py
+++ b/handlers/aws/kinesis_trigger.py
@@ -31,12 +31,14 @@ def _handle_kinesis_continuation(
     """
 
     sequence_number = kinesis_record["kinesis"]["sequenceNumber"]
+    partition_key = kinesis_record["kinesis"]["partitionKey"]
     stream_type, stream_name, _ = get_kinesis_stream_name_type_and_region_from_arn(event_input_id)
 
     message_attributes = {
         "config": {"StringValue": config_yaml, "DataType": "String"},
         "originalStreamType": {"StringValue": stream_type, "DataType": "String"},
         "originalStreamName": {"StringValue": stream_name, "DataType": "String"},
+        "originalPartitionKey": {"StringValue": partition_key, "DataType": "String"},
         "originalSequenceNumber": {"StringValue": sequence_number, "DataType": "String"},
         "originalEventSourceARN": {"StringValue": event_input_id, "DataType": "String"},
     }
@@ -85,6 +87,7 @@ def _handle_kinesis_record(
     account_id = get_account_id_from_arn(input_id)
 
     for kinesis_record_n, kinesis_record in enumerate(event["Records"]):
+        shared_logger.info(kinesis_record)
         storage: ProtocolStorage = StorageFactory.create(
             storage_type="payload",
             payload=kinesis_record["kinesis"]["data"],
@@ -118,6 +121,7 @@ def _handle_kinesis_record(
                         "kinesis": {
                             "type": stream_type,
                             "name": stream_name,
+                            "partition_key": kinesis_record["kinesis"]["partitionKey"],
                             "sequence_number": kinesis_record["kinesis"]["sequenceNumber"],
                         }
                     },

--- a/handlers/aws/s3_sqs_trigger.py
+++ b/handlers/aws/s3_sqs_trigger.py
@@ -84,6 +84,7 @@ def _handle_s3_sqs_event(
         aws_region = s3_record["awsRegion"]
         bucket_arn = unquote_plus(s3_record["s3"]["bucket"]["arn"], "utf-8")
         object_key = unquote_plus(s3_record["s3"]["object"]["key"], "utf-8")
+        event_time = int(datetime.datetime.strptime(s3_record["eventTime"], "%Y-%m-%dT%H:%M:%S.%fZ").timestamp() * 1000)
         last_ending_offset = s3_record["last_ending_offset"] if "last_ending_offset" in s3_record else 0
 
         assert len(bucket_arn) > 0
@@ -132,7 +133,7 @@ def _handle_s3_sqs_event(
                         "account": {"id": account_id},
                     },
                 },
-                "meta": {},
+                "meta": {"event_time": event_time},
             }
 
             yield es_event, ending_offset, event_expanded_offset, s3_record_n

--- a/handlers/aws/sqs_trigger.py
+++ b/handlers/aws/sqs_trigger.py
@@ -169,6 +169,9 @@ def _handle_sqs_event(
             assert "originalStreamName" in payload
             stream_name = payload["originalStreamName"]["stringValue"]
 
+            assert "originalPartitionKey" in payload
+            partition_key = payload["originalPartitionKey"]["stringValue"]
+
             assert "originalSequenceNumber" in payload
             sequence_number = payload["originalSequenceNumber"]["stringValue"]
 
@@ -178,6 +181,7 @@ def _handle_sqs_event(
                 "kinesis": {
                     "type": stream_type,
                     "name": stream_name,
+                    "partition_key": partition_key,
                     "sequence_number": sequence_number,
                 }
             }

--- a/handlers/aws/sqs_trigger.py
+++ b/handlers/aws/sqs_trigger.py
@@ -175,6 +175,9 @@ def _handle_sqs_event(
             assert "originalSequenceNumber" in payload
             sequence_number = payload["originalSequenceNumber"]["stringValue"]
 
+            assert "originalApproximateArrivalTimestamp" in payload
+            approximate_arrival_timestamp = int(float(payload["originalApproximateArrivalTimestamp"]["stringValue"]))
+
             es_event["fields"]["log"]["file"]["path"] = input_id
 
             es_event["fields"]["aws"] = {
@@ -183,6 +186,7 @@ def _handle_sqs_event(
                     "name": stream_name,
                     "partition_key": partition_key,
                     "sequence_number": sequence_number,
+                    "approximate_arrival_timestamp": approximate_arrival_timestamp,
                 }
             }
 

--- a/handlers/aws/sqs_trigger.py
+++ b/handlers/aws/sqs_trigger.py
@@ -201,8 +201,8 @@ def _handle_sqs_event(
                     "name": stream_name,
                     "partition_key": partition_key,
                     "sequence_number": sequence_number,
-                    "approximate_arrival_timestamp": approximate_arrival_timestamp,
                 }
             }
+            es_event["meta"]["approximate_arrival_timestamp"] = approximate_arrival_timestamp
 
         yield es_event, ending_offset, event_expanded_offset

--- a/handlers/aws/sqs_trigger.py
+++ b/handlers/aws/sqs_trigger.py
@@ -153,6 +153,9 @@ def _handle_sqs_event(
             assert "originalLogStream" in payload
             log_stream_name = payload["originalLogStream"]["stringValue"]
 
+            assert "originalEventTimestamp" in payload
+            event_timestamp = int(float(payload["originalEventTimestamp"]["stringValue"]))
+
             es_event["fields"]["log"]["file"]["path"] = f"{log_group_name}/{log_stream_name}"
 
             es_event["fields"]["aws"] = {
@@ -162,6 +165,8 @@ def _handle_sqs_event(
                     "event_id": event_id,
                 }
             }
+
+            es_event["meta"]["event_timestamp"] = event_timestamp
         else:
             assert "originalStreamType" in payload
             stream_type = payload["originalStreamType"]["stringValue"]

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -440,8 +440,9 @@ def s3_object_id(event_payload: dict[str, Any]) -> str:
     offset: int = event_payload["fields"]["log"]["offset"]
     bucket_arn: str = event_payload["fields"]["aws"]["s3"]["bucket"]["arn"]
     object_key: str = event_payload["fields"]["aws"]["s3"]["object"]["key"]
+    event_time: int = event_payload["meta"]["event_time"]
 
-    src: str = f"{bucket_arn}-{object_key}"
+    src: str = f"{event_time}-{bucket_arn}-{object_key}"
 
     return f"{src}-{offset:012d}"
 

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -479,7 +479,6 @@ def kinesis_record_id(event_payload: dict[str, Any]) -> str:
     """
     Generates a unique event id given the payload of an event from a kinesis stream
     """
-    shared_logger.info(event_payload)
     offset: int = event_payload["fields"]["log"]["offset"]
     stream_type: str = event_payload["fields"]["aws"]["kinesis"]["type"]
     stream_name: str = event_payload["fields"]["aws"]["kinesis"]["name"]

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -471,8 +471,9 @@ def sqs_object_id(event_payload: dict[str, Any]) -> str:
     offset: int = event_payload["fields"]["log"]["offset"]
     queue_name: str = event_payload["fields"]["aws"]["sqs"]["name"]
     message_id: str = event_payload["fields"]["aws"]["sqs"]["message_id"]
+    sent_timestamp: int = event_payload["meta"]["sent_timestamp"]
 
-    src: str = f"{queue_name}-{message_id}"
+    src: str = f"{sent_timestamp}-{queue_name}-{message_id}"
 
     return f"{src}-{offset:012d}"
 

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -484,8 +484,9 @@ def kinesis_record_id(event_payload: dict[str, Any]) -> str:
     stream_name: str = event_payload["fields"]["aws"]["kinesis"]["name"]
     partition_key: str = event_payload["fields"]["aws"]["kinesis"]["partition_key"]
     sequence_number: str = event_payload["fields"]["aws"]["kinesis"]["sequence_number"]
+    approximate_arrival_timestamp: int = event_payload["fields"]["aws"]["kinesis"]["approximate_arrival_timestamp"]
 
-    src: str = f"{stream_type}-{stream_name}-{partition_key}-{sequence_number}"
+    src: str = f"{approximate_arrival_timestamp}-{stream_type}-{stream_name}-{partition_key}-{sequence_number}"
 
     return f"{src}-{offset:012d}"
 

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -456,8 +456,9 @@ def cloudwatch_logs_object_id(event_payload: dict[str, Any]) -> str:
     group_name: str = event_payload["fields"]["aws"]["cloudwatch"]["log_group"]
     stream_name: str = event_payload["fields"]["aws"]["cloudwatch"]["log_stream"]
     event_id: str = event_payload["fields"]["aws"]["cloudwatch"]["event_id"]
+    event_timestamp: int = event_payload["meta"]["event_timestamp"]
 
-    src: str = f"{group_name}-{stream_name}-{event_id}"
+    src: str = f"{event_timestamp}-{group_name}-{stream_name}-{event_id}"
 
     return f"{src}-{offset:012d}"
 

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -487,7 +487,7 @@ def kinesis_record_id(event_payload: dict[str, Any]) -> str:
     stream_name: str = event_payload["fields"]["aws"]["kinesis"]["name"]
     partition_key: str = event_payload["fields"]["aws"]["kinesis"]["partition_key"]
     sequence_number: str = event_payload["fields"]["aws"]["kinesis"]["sequence_number"]
-    approximate_arrival_timestamp: int = event_payload["fields"]["aws"]["kinesis"]["approximate_arrival_timestamp"]
+    approximate_arrival_timestamp: int = event_payload["meta"]["approximate_arrival_timestamp"]
 
     src: str = f"{approximate_arrival_timestamp}-{stream_type}-{stream_name}-{partition_key}-{sequence_number}"
 

--- a/publish_lambda.sh
+++ b/publish_lambda.sh
@@ -350,7 +350,7 @@ def create_policy(publish_config: dict[str, Any]):
             assert isinstance(cloudwatch_logs_event, dict)
 
             if "arn" in cloudwatch_logs_event:
-                cloudwatch_logs_event_arn = cloudwatch_logs_event["arn"]
+                cloudwatch_logs_event_arn = cloudwatch_logs_event["arn"].split(':')
 
                 if len(cloudwatch_logs_event_arn) == 7:
                     cloudwatch_logs_group_arn[f"{':'.join(cloudwatch_logs_event_arn[0:-1])}:*:*"] = True

--- a/tests/handlers/aws/test_handler.py
+++ b/tests/handlers/aws/test_handler.py
@@ -1764,9 +1764,12 @@ class TestLambdaHandlerSuccessMixedInput(IntegrationTestCase):
         )
         event_s3 = _event_from_sqs_message(queue_attributes=self._queues_info["source-s3-sqs-queue"])
         bucket_arn: str = "arn:aws:s3:::test-bucket"
+        event_time = int(
+            datetime.datetime.strptime("2021-09-08T18:34:25.042Z", "%Y-%m-%dT%H:%M:%S.%fZ").timestamp() * 1000
+        )
 
-        prefix_s3_first = f"{bucket_arn}-{first_filename}"
-        prefix_s3_second = f"{bucket_arn}-{second_filename}"
+        prefix_s3_first = f"{event_time}-{bucket_arn}-{first_filename}"
+        prefix_s3_second = f"{event_time}-{bucket_arn}-{second_filename}"
 
         _event_to_sqs_message(queue_attributes=self._queues_info["source-sqs-queue"], message_body=self._cloudwatch_log)
         event_sqs = _event_from_sqs_message(queue_attributes=self._queues_info["source-sqs-queue"])
@@ -2126,9 +2129,12 @@ class TestLambdaHandlerSuccessMixedInput(IntegrationTestCase):
 
         s3_events = _event_from_sqs_message(queue_attributes=self._queues_info["source-s3-sqs-queue"])
         bucket_arn: str = "arn:aws:s3:::test-bucket"
+        event_time = int(
+            datetime.datetime.strptime("2021-09-08T18:34:25.042Z", "%Y-%m-%dT%H:%M:%S.%fZ").timestamp() * 1000
+        )
 
-        prefix_s3_first = f"{bucket_arn}-{first_filename}"
-        prefix_s3_second = f"{bucket_arn}-{second_filename}"
+        prefix_s3_first = f"{event_time}-{bucket_arn}-{first_filename}"
+        prefix_s3_second = f"{event_time}-{bucket_arn}-{second_filename}"
 
         _event_to_sqs_message(queue_attributes=self._queues_info["source-sqs-queue"], message_body=self._cloudwatch_log)
         event_sqs = _event_from_sqs_message(queue_attributes=self._queues_info["source-sqs-queue"])
@@ -3091,7 +3097,11 @@ class TestLambdaHandlerSuccessS3SQS(IntegrationTestCase):
             "aws-account-id_CloudTrail-Digest_region_end-time_random-string.log.gz"
         )
 
-        prefix_s3: str = f"arn:aws:s3:::test-bucket-{filename}"
+        event_time = int(
+            datetime.datetime.strptime("2021-09-08T18:34:25.042Z", "%Y-%m-%dT%H:%M:%S.%fZ").timestamp() * 1000
+        )
+
+        prefix_s3: str = f"{event_time}-arn:aws:s3:::test-bucket-{filename}"
         # Create an expected id so that es.send will fail
         self._es_client.index(
             index="logs-aws.cloudtrail-default",

--- a/tests/handlers/aws/test_handler.py
+++ b/tests/handlers/aws/test_handler.py
@@ -2534,6 +2534,10 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
         kinesis_event = _event_from_kinesis_records(
             records=records, stream_attribute=self._kinesis_streams_info["source-kinesis"]
         )
+        timestamp_first = datetime.datetime(2014, 12, 29).timestamp()
+        timestamp_second = datetime.datetime(2014, 12, 28).timestamp()
+        kinesis_event["Records"][0]["kinesis"]["approximateArrivalTimestamp"] = timestamp_first
+        kinesis_event["Records"][1]["kinesis"]["approximateArrivalTimestamp"] = timestamp_second
 
         first_call = handler(kinesis_event, ctx)  # type:ignore
 
@@ -2557,6 +2561,7 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
                 "partition_key": "PartitionKey",
                 "name": self._kinesis_streams_info["source-kinesis"]["StreamDescription"]["StreamName"],
                 "sequence_number": kinesis_event["Records"][0]["kinesis"]["sequenceNumber"],
+                "approximate_arrival_timestamp": int(timestamp_first),
             }
         }
         assert res["hits"]["hits"][0]["_source"]["cloud"] == {
@@ -2590,6 +2595,7 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
                 "partition_key": "PartitionKey",
                 "name": self._kinesis_streams_info["source-kinesis"]["StreamDescription"]["StreamName"],
                 "sequence_number": kinesis_event["Records"][0]["kinesis"]["sequenceNumber"],
+                "approximate_arrival_timestamp": int(timestamp_first),
             }
         }
         assert res["hits"]["hits"][1]["_source"]["cloud"] == {
@@ -2631,6 +2637,7 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
                 "partition_key": "PartitionKey",
                 "name": self._kinesis_streams_info["source-kinesis"]["StreamDescription"]["StreamName"],
                 "sequence_number": kinesis_event["Records"][1]["kinesis"]["sequenceNumber"],
+                "approximate_arrival_timestamp": int(timestamp_second),
             }
         }
         assert res["hits"]["hits"][2]["_source"]["cloud"] == {
@@ -2726,14 +2733,22 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
         event = _event_from_kinesis_records(
             records=records, stream_attribute=self._kinesis_streams_info["source-kinesis"]
         )
+        timestamp_first = datetime.datetime(2014, 12, 29).timestamp()
+        timestamp_second = datetime.datetime(2014, 12, 28).timestamp()
+        event["Records"][0]["kinesis"]["approximateArrivalTimestamp"] = timestamp_first
+        event["Records"][1]["kinesis"]["approximateArrivalTimestamp"] = timestamp_second
 
         stream_name: str = self._kinesis_streams_info["source-kinesis"]["StreamDescription"]["StreamName"]
 
         sequence_number_first_record = event["Records"][0]["kinesis"]["sequenceNumber"]
-        prefix_first_record: str = f"stream-{stream_name}-{partition_key}-{sequence_number_first_record}"
+        prefix_first_record: str = (
+            f"{int(timestamp_first)}-stream-{stream_name}-{partition_key}-{sequence_number_first_record}"
+        )
 
         sequence_number_second_record = event["Records"][1]["kinesis"]["sequenceNumber"]
-        prefix_second_record: str = f"stream-{stream_name}-{partition_key}-{sequence_number_second_record}"
+        prefix_second_record: str = (
+            f"{int(timestamp_second)}-stream-{stream_name}-{partition_key}-{sequence_number_second_record}"
+        )
 
         # Create an expected id so that es.send will fail
         self._es_client.index(
@@ -2774,6 +2789,7 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
                 "partition_key": partition_key,
                 "name": self._kinesis_streams_info["source-kinesis"]["StreamDescription"]["StreamName"],
                 "sequence_number": event["Records"][0]["kinesis"]["sequenceNumber"],
+                "approximate_arrival_timestamp": int(timestamp_first),
             }
         }
         assert res["hits"]["hits"][0]["_source"]["cloud"] == {
@@ -2796,6 +2812,7 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
                 "partition_key": partition_key,
                 "name": self._kinesis_streams_info["source-kinesis"]["StreamDescription"]["StreamName"],
                 "sequence_number": event["Records"][1]["kinesis"]["sequenceNumber"],
+                "approximate_arrival_timestamp": int(timestamp_second),
             }
         }
         assert res["hits"]["hits"][1]["_source"]["cloud"] == {
@@ -2848,6 +2865,7 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
                 "partition_key": partition_key,
                 "name": self._kinesis_streams_info["source-kinesis"]["StreamDescription"]["StreamName"],
                 "sequence_number": event["Records"][0]["kinesis"]["sequenceNumber"],
+                "approximate_arrival_timestamp": int(timestamp_first),
             }
         }
         assert res["hits"]["hits"][2]["_source"]["cloud"] == {

--- a/tests/handlers/aws/test_handler.py
+++ b/tests/handlers/aws/test_handler.py
@@ -2593,7 +2593,6 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
                 "partition_key": "PartitionKey",
                 "name": self._kinesis_streams_info["source-kinesis"]["StreamDescription"]["StreamName"],
                 "sequence_number": kinesis_event["Records"][0]["kinesis"]["sequenceNumber"],
-                "approximate_arrival_timestamp": int(timestamp_first),
             }
         }
         assert res["hits"]["hits"][0]["_source"]["cloud"] == {
@@ -2627,7 +2626,6 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
                 "partition_key": "PartitionKey",
                 "name": self._kinesis_streams_info["source-kinesis"]["StreamDescription"]["StreamName"],
                 "sequence_number": kinesis_event["Records"][0]["kinesis"]["sequenceNumber"],
-                "approximate_arrival_timestamp": int(timestamp_first),
             }
         }
         assert res["hits"]["hits"][1]["_source"]["cloud"] == {
@@ -2669,7 +2667,6 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
                 "partition_key": "PartitionKey",
                 "name": self._kinesis_streams_info["source-kinesis"]["StreamDescription"]["StreamName"],
                 "sequence_number": kinesis_event["Records"][1]["kinesis"]["sequenceNumber"],
-                "approximate_arrival_timestamp": int(timestamp_second),
             }
         }
         assert res["hits"]["hits"][2]["_source"]["cloud"] == {
@@ -2774,12 +2771,12 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
 
         sequence_number_first_record = event["Records"][0]["kinesis"]["sequenceNumber"]
         prefix_first_record: str = (
-            f"{int(timestamp_first)}-stream-{stream_name}-{partition_key}-{sequence_number_first_record}"
+            f"{int(timestamp_first*1000)}-stream-{stream_name}-{partition_key}-{sequence_number_first_record}"
         )
 
         sequence_number_second_record = event["Records"][1]["kinesis"]["sequenceNumber"]
         prefix_second_record: str = (
-            f"{int(timestamp_second)}-stream-{stream_name}-{partition_key}-{sequence_number_second_record}"
+            f"{int(timestamp_second*1000)}-stream-{stream_name}-{partition_key}-{sequence_number_second_record}"
         )
 
         # Create an expected id so that es.send will fail
@@ -2821,7 +2818,6 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
                 "partition_key": partition_key,
                 "name": self._kinesis_streams_info["source-kinesis"]["StreamDescription"]["StreamName"],
                 "sequence_number": event["Records"][0]["kinesis"]["sequenceNumber"],
-                "approximate_arrival_timestamp": int(timestamp_first),
             }
         }
         assert res["hits"]["hits"][0]["_source"]["cloud"] == {
@@ -2844,7 +2840,6 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
                 "partition_key": partition_key,
                 "name": self._kinesis_streams_info["source-kinesis"]["StreamDescription"]["StreamName"],
                 "sequence_number": event["Records"][1]["kinesis"]["sequenceNumber"],
-                "approximate_arrival_timestamp": int(timestamp_second),
             }
         }
         assert res["hits"]["hits"][1]["_source"]["cloud"] == {
@@ -2897,7 +2892,6 @@ class TestLambdaHandlerSuccessKinesisDataStream(IntegrationTestCase):
                 "partition_key": partition_key,
                 "name": self._kinesis_streams_info["source-kinesis"]["StreamDescription"]["StreamName"],
                 "sequence_number": event["Records"][0]["kinesis"]["sequenceNumber"],
-                "approximate_arrival_timestamp": int(timestamp_first),
             }
         }
         assert res["hits"]["hits"][2]["_source"]["cloud"] == {

--- a/tests/handlers/aws/test_handler.py
+++ b/tests/handlers/aws/test_handler.py
@@ -1252,6 +1252,10 @@ def _event_from_sqs_message(queue_attributes: dict[str, Any]) -> dict[str, Any]:
 
                     message["messageAttributes"][attribute] = new_attribute
 
+            if "sent_timestamp" in queue_attributes:
+                message["attributes"] = {}
+                message["attributes"]["SentTimestamp"] = queue_attributes["sent_timestamp"]
+
             message["eventSource"] = "aws:sqs"
             message["eventSourceARN"] = queue_attributes["QueueArn"]
 
@@ -1774,10 +1778,13 @@ class TestLambdaHandlerSuccessMixedInput(IntegrationTestCase):
         prefix_s3_second = f"{event_time}-{bucket_arn}-{second_filename}"
 
         _event_to_sqs_message(queue_attributes=self._queues_info["source-sqs-queue"], message_body=self._cloudwatch_log)
-        event_sqs = _event_from_sqs_message(queue_attributes=self._queues_info["source-sqs-queue"])
+        timestamp = str(int(datetime.datetime.utcnow().timestamp()))
+        queue_attributes = self._queues_info["source-sqs-queue"]
+        queue_attributes["sent_timestamp"] = timestamp
+        event_sqs = _event_from_sqs_message(queue_attributes=queue_attributes)
 
         message_id = event_sqs["Records"][0]["messageId"]
-        prefix_sqs: str = f"source-sqs-queue-{message_id}"
+        prefix_sqs: str = f"{timestamp}-source-sqs-queue-{message_id}"
 
         _event_to_cloudwatch_logs(
             group_name="source-group",
@@ -2146,7 +2153,10 @@ class TestLambdaHandlerSuccessMixedInput(IntegrationTestCase):
         prefix_s3_second = f"{event_time}-{bucket_arn}-{second_filename}"
 
         _event_to_sqs_message(queue_attributes=self._queues_info["source-sqs-queue"], message_body=self._cloudwatch_log)
-        event_sqs = _event_from_sqs_message(queue_attributes=self._queues_info["source-sqs-queue"])
+        timestamp = str(int(datetime.datetime.utcnow().timestamp()))
+        queue_attributes = self._queues_info["source-sqs-queue"]
+        queue_attributes["sent_timestamp"] = timestamp
+        event_sqs = _event_from_sqs_message(queue_attributes=queue_attributes)
 
         _event_to_sqs_message(
             queue_attributes=self._queues_info["source-no-conf-queue"], message_body=self._cloudwatch_log
@@ -2154,7 +2164,7 @@ class TestLambdaHandlerSuccessMixedInput(IntegrationTestCase):
         event_no_config = _event_from_sqs_message(queue_attributes=self._queues_info["source-no-conf-queue"])
 
         message_id = event_sqs["Records"][0]["messageId"]
-        prefix_sqs: str = f"source-sqs-queue-{message_id}"
+        prefix_sqs: str = f"{timestamp}-source-sqs-queue-{message_id}"
 
         _event_to_cloudwatch_logs(
             group_name="source-group",
@@ -3444,10 +3454,13 @@ class TestLambdaHandlerSuccessSQS(IntegrationTestCase):
 
         _event_to_sqs_message(queue_attributes=self._queues_info["source-queue"], message_body=cloudwatch_log)
 
-        event = _event_from_sqs_message(queue_attributes=self._queues_info["source-queue"])
+        timestamp = str(int(datetime.datetime.utcnow().timestamp()))
+        queue_attributes = self._queues_info["source-queue"]
+        queue_attributes["sent_timestamp"] = timestamp
+        event = _event_from_sqs_message(queue_attributes=queue_attributes)
 
         message_id = event["Records"][0]["messageId"]
-        prefix: str = f"source-queue-{message_id}"
+        prefix: str = f"{timestamp}-source-queue-{message_id}"
 
         # Create an expected id so that es.send will fail
         self._es_client.index(
@@ -3562,7 +3575,10 @@ class TestLambdaHandlerSuccessSQS(IntegrationTestCase):
 
         _event_to_sqs_message(queue_attributes=self._queues_info["source-queue"], message_body=cloudwatch_log)
 
-        event = _event_from_sqs_message(queue_attributes=self._queues_info["source-queue"])
+        timestamp = str(int(datetime.datetime.utcnow().timestamp()))
+        queue_attributes = self._queues_info["source-queue"]
+        queue_attributes["sent_timestamp"] = timestamp
+        event = _event_from_sqs_message(queue_attributes=queue_attributes)
 
         first_call = handler(event, ctx)  # type:ignore
 
@@ -3988,7 +4004,10 @@ class TestLambdaHandlerFailureSSLFingerprint(IntegrationTestCase):
 
         _event_to_sqs_message(queue_attributes=self._queues_info["source-queue"], message_body=cloudwatch_log)
 
-        event = _event_from_sqs_message(queue_attributes=self._queues_info["source-queue"])
+        timestamp = str(int(datetime.datetime.utcnow().timestamp()))
+        queue_attributes = self._queues_info["source-queue"]
+        queue_attributes["sent_timestamp"] = timestamp
+        event = _event_from_sqs_message(queue_attributes=queue_attributes)
 
         first_call = handler(event, ctx)  # type:ignore
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR changes the event ID generation logic for all inputs. The new logic combines different data provided by AWS (e.g S3 bucket-name, Kinesis Record Sequence Number, etc) to generate IDs. It removes any call to `hashlib.sha256` that is not really required and only adds further computational burden to the Lambda.
Integration tests were updated accordingly, to accommodate this change.

Docs will be updated as part of another PR: https://github.com/elastic/observability-docs/pull/2473 . However, a generic note about this change has been added to the README.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

In its current implementation, the pool of possible IDs is too small to avoid duplicates. More details can be found at https://github.com/elastic/elastic-serverless-forwarder/issues/212

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md`


## How to test this PR locally

`make unit-test`
`make integration-test`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-serverless-forwarder/issues/212


