### PR TITLE
Handle _id not matching in failed actions for elasticsearch shipper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-### v1.6.1 - 2023/02/02
+### v1.6.1 - 2023/02/03
 ##### Bug fixes
 * Changed event ID format to use a SHA3 384bit hash of AWS-provided ids: [#227](https://github.com/elastic/elastic-serverless-forwarder/pull/227)
 * Fix `kinesis-data-stream` data payload type decoding and empty fields in message attributes in `sqs` continuation: [#228](https://github.com/elastic/elastic-serverless-forwarder/pull/228)
+* Handle missing matching `_id` from failed actions in elasticsearch output: [#230](https://github.com/elastic/elastic-serverless-forwarder/pull/230)
 
 ### v1.6.0 - 2023/01/26
 ##### Features

--- a/shippers/es.py
+++ b/shippers/es.py
@@ -167,7 +167,10 @@ class ElasticsearchShipper:
         failed = len(errors[1])
         for error in errors[1]:
             action_failed = [action for action in self._bulk_actions if action["_id"] == error["create"]["_id"]]
-            assert len(action_failed) == 1
+            # an ingestion pipeline might override the _id, we can only skip in this case
+            if len(action_failed) != 1:
+                continue
+
             shared_logger.warning(
                 "elasticsearch shipper", extra={"error": error["create"]["error"], "_id": error["create"]["_id"]}
             )


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
Bug
## What does this PR do?
An ingestion pipeline might override the `_id` of a document: the only way to get the original payload of a document failed to be ingested is to match by `_id` value in the error payload returned by the bulk API. We had an assertion about the fact the a matching `_id` was always present, but that's not the case when an ingestion pipeline overrides the `_id`. We now handle gracefully that case.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
In case an event failed to be ingested, when an ingestion pipeline overrides its `_id`, the forwarder exits unexpectedly. If this happens before the last bulk request, events will be lost
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
