### PR TITLE
Fixed shipper cache to include output type in the key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v1.7.1 - 2023/02/16
+##### Bug fixes
+* Fix wrong resolved `expand_event_list_from_field` with AWS CloudTrail due to race condition [#244](https://github.com/elastic/elastic-serverless-forwarder/pull/244)
+* Fix shipper cache to include output type in the key [#245](https://github.com/elastic/elastic-serverless-forwarder/pull/245)
+
 ### v1.7.0 - 2023/02/01
 ##### Features
 * Added support for Logstash as output (Technical Preview) [#210](https://github.com/elastic/elastic-serverless-forwarder/pull/210)

--- a/handlers/aws/handler.py
+++ b/handlers/aws/handler.py
@@ -85,12 +85,13 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
         for replay_record in lambda_event["Records"]:
             event = json_parser(replay_record["body"])
             input_id = event["event_input_id"]
+            output_type = event["output_type"]
             if input_id not in shipper_cache:
                 shipper = get_shipper_for_replay_event(
                     config=config,
-                    output_type=event["output_type"],
+                    output_type=output_type,
                     output_args=event["output_args"],
-                    event_input_id=event["event_input_id"],
+                    event_input_id=input_id,
                     replay_handler=replay_handler,
                 )
 
@@ -101,9 +102,9 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
                     )
                     continue
 
-                shipper_cache[input_id] = shipper
+                shipper_cache[input_id + output_type] = shipper
             else:
-                shipper = shipper_cache[input_id]
+                shipper = shipper_cache[input_id + output_type]
 
             shipper.send(event["event_payload"])
             replay_handler.add_event_id_with_receipt_handle(

--- a/handlers/aws/handler.py
+++ b/handlers/aws/handler.py
@@ -86,7 +86,8 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
             event = json_parser(replay_record["body"])
             input_id = event["event_input_id"]
             output_type = event["output_type"]
-            if input_id + output_type not in shipper_cache:
+            shipper_id = input_id + output_type
+            if shipper_id not in shipper_cache:
                 shipper = get_shipper_for_replay_event(
                     config=config,
                     output_type=output_type,
@@ -102,9 +103,9 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
                     )
                     continue
 
-                shipper_cache[input_id + output_type] = shipper
+                shipper_cache[shipper_id] = shipper
             else:
-                shipper = shipper_cache[input_id + output_type]
+                shipper = shipper_cache[shipper_id]
 
             shipper.send(event["event_payload"])
             replay_handler.add_event_id_with_receipt_handle(

--- a/handlers/aws/handler.py
+++ b/handlers/aws/handler.py
@@ -86,7 +86,7 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
             event = json_parser(replay_record["body"])
             input_id = event["event_input_id"]
             output_type = event["output_type"]
-            if input_id not in shipper_cache:
+            if input_id + output_type not in shipper_cache:
                 shipper = get_shipper_for_replay_event(
                     config=config,
                     output_type=output_type,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

With the addition of Logstash as output, we might have multiple outputs defined for one input. This needs to be considered in the key space for shipper_cache

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

If a user has a configuration like

```
inputs:
  - type: s3-sqs
    id: arn:aws:sqs:eu-central-1:627286350134:test-esf-sqs-s3
    json_content_type: disabled
    outputs:
      - type: logstash
        [etc]
      - type: elasticsearch
        [etc]
```

Shipper cache would include only one entry for `arn:aws:sqs:eu-central-1:627286350134:test-esf-sqs-s3`, instead of one of `logstash` and one for `elasticsearch`, if both shippers fail

