### PR TITLE
action: notify Coverage as GitHub comment (PR only)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      pull-requests: write # for marocchino/sticky-pull-request-comment
+
     steps:
     - name: Cleanup some tools from the workers to fix no space left
       run: |-
@@ -56,6 +59,14 @@ jobs:
         filename: coverage.xml
         format: 'markdown'
         output: 'both'
+
+    # Version https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.5.0
+    - name: Add Coverage PR Comment
+      uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd
+      if: github.event_name == 'pull_request' && (success() || failure())
+      with:
+        recreate: true
+        path: code-coverage-results.md
 
     - name: Write to Job Summary
       if: success() || failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,15 @@ jobs:
         format: 'markdown'
         output: 'both'
 
+    - name: Store coverage results
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage
+        path: |
+          coverage.xml
+          code-coverage-results.md
+
     # Version https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.5.0
     - name: Add Coverage PR Comment
       uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd


### PR DESCRIPTION
## What does this PR do?

Enable coverage reporting and storing artifacts so they can be useful for debugging purposes.

## Why is it important?

Visualise the coverage as we used to have with Jenkins

Originally removed for required extra permissions -> https://github.com/elastic/elastic-serverless-forwarder/pull/223/commits/168d8022435f04f9cf9d879d21fefcfbf81da8ab#r1094793556