### PR TITLE
action: notify Coverage as GitHub comment (PR only)

### DIFF
--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   report:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.event == 'pull_request' }}
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/test-report@current
         with:
@@ -20,12 +19,17 @@ jobs:
           path: "**/elastic-serverless-forwarder-junit.xml"                  # Path to test results (inside artifact .zip)
           reporter: java-junit              # Format of test results
           output-to: step-summary           # Write summary in the PR
-      - uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: ${{ github.event.workflow_run.workflow_id }}
-          commit: ${{ github.event.workflow_run.head_commit.id }}
-          name: test-results
+  coverage:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    steps:
+      - name: Download artifacts
+        run: >
+          gh run download ${{ github.event.workflow_run.id }}
+          --name test-results
+          --repo "${GITHUB_REPOSITORY}"
+          --dir .
+        env:
+          GH_TOKEN: ${{ github.token }}
       - uses: 5monkeys/cobertura-action@v13
         with:
           path: "**/coverage.xml"

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   report:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
     steps:
       - name: ${{ github.event.workflow_run.event }}
         run: echo "${{ github.event.workflow_run.pull_requests[0].number }}"
@@ -22,9 +23,17 @@ jobs:
           path: "**/*.xml"                  # Path to test results (inside artifact .zip)
           reporter: java-junit              # Format of test results
           output-to: step-summary           # Write summary in the PR
+      - name: dawidd6/action-download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          name: test-results
       - name: 5monkeys/cobertura-action
         uses: 5monkeys/cobertura-action@v13
         with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           skip_covered: false
           minimum_coverage: 100
           fail_below_threshold: true

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -20,3 +20,12 @@ jobs:
           path: "**/*.xml"                  # Path to test results (inside artifact .zip)
           reporter: java-junit              # Format of test results
           output-to: step-summary           # Write summary in the PR
+      - uses: 5monkeys/cobertura-action@v13
+        with:
+          skip_covered: false
+          minimum_coverage: 100
+          fail_below_threshold: true
+          show_line: true
+          show_branch: true
+          show_missing: true
+          pull_request_number: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -12,6 +12,8 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
+      - name: ${{ github.event.workflow_run.event }}
+        run: echo "${{ github.event.workflow_run.pull_requests[0].number }}"
       - name: elastic/apm-pipeline-library/.github/actions/test-report
         uses: elastic/apm-pipeline-library/.github/actions/test-report@current
         with:

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -21,6 +21,7 @@ jobs:
           output-to: step-summary           # Write summary in the PR
   coverage:
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
         run: >

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -13,10 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_commit.id }}
       - uses: elastic/apm-pipeline-library/.github/actions/test-report@current
         with:
           artifact: test-results            # artifact name
@@ -39,4 +35,3 @@ jobs:
           show_line: true
           show_branch: true
           show_missing: true
-          pull_request_number: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -19,3 +19,4 @@ jobs:
           name: JUnit Tests                 # Name of the check run which will be created
           path: "**/*.xml"                  # Path to test results (inside artifact .zip)
           reporter: java-junit              # Format of test results
+          output-to: step-summary           # Write summary in the PR

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -13,27 +13,26 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     steps:
-      - name: ${{ github.event.workflow_run.event }}
-        run: echo "${{ github.event.workflow_run.pull_requests[0].number }}"
-      - name: elastic/apm-pipeline-library/.github/actions/test-report
-        uses: elastic/apm-pipeline-library/.github/actions/test-report@current
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_commit.id }}
+      - uses: elastic/apm-pipeline-library/.github/actions/test-report@current
         with:
           artifact: test-results            # artifact name
           name: JUnit Tests                 # Name of the check run which will be created
-          path: "**/*.xml"                  # Path to test results (inside artifact .zip)
+          path: "**/elastic-serverless-forwarder-junit.xml"                  # Path to test results (inside artifact .zip)
           reporter: java-junit              # Format of test results
           output-to: step-summary           # Write summary in the PR
-      - name: dawidd6/action-download-artifact
-        uses: dawidd6/action-download-artifact@v2
+      - uses: dawidd6/action-download-artifact@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ${{ github.event.workflow_run.workflow_id }}
           commit: ${{ github.event.workflow_run.head_commit.id }}
           name: test-results
-      - name: 5monkeys/cobertura-action
-        uses: 5monkeys/cobertura-action@v13
+      - uses: 5monkeys/cobertura-action@v13
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          path: "**/coverage.xml"
           skip_covered: false
           minimum_coverage: 100
           fail_below_threshold: true

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   report:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/test-report@current

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -10,17 +10,18 @@ on:
 
 jobs:
   report:
-    if: ${{ github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/apm-pipeline-library/.github/actions/test-report@current
+      - name: elastic/apm-pipeline-library/.github/actions/test-report
+        uses: elastic/apm-pipeline-library/.github/actions/test-report@current
         with:
           artifact: test-results            # artifact name
           name: JUnit Tests                 # Name of the check run which will be created
           path: "**/*.xml"                  # Path to test results (inside artifact .zip)
           reporter: java-junit              # Format of test results
           output-to: step-summary           # Write summary in the PR
-      - uses: 5monkeys/cobertura-action@v13
+      - name: 5monkeys/cobertura-action
+        uses: 5monkeys/cobertura-action@v13
         with:
           skip_covered: false
           minimum_coverage: 100

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -31,7 +31,7 @@ jobs:
           --dir .
         env:
           GH_TOKEN: ${{ github.token }}
-      - uses: 5monkeys/cobertura-action@v13
+      - uses: 5monkeys/cobertura-action@4157521
         with:
           path: "**/coverage.xml"
           skip_covered: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      pull-requests: write # for marocchino/sticky-pull-request-comment
+
     steps:
     - name: Cleanup some tools from the workers to fix no space left
       run: |-
@@ -56,6 +59,14 @@ jobs:
         filename: coverage.xml
         format: 'markdown'
         output: 'both'
+
+    # Version https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.5.0
+    - name: Add Coverage PR Comment
+      uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd
+      if: github.event_name == 'pull_request' && (success() || failure())
+      with:
+        recreate: true
+        path: code-coverage-results.md
 
     - name: Write to Job Summary
       if: success() || failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,15 @@ jobs:
         format: 'markdown'
         output: 'both'
 
+    - name: Store coverage results
+      if: success() || failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage
+        path: |
+          coverage.xml
+          code-coverage-results.md
+
     # Version https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.5.0
     - name: Add Coverage PR Comment
       uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,6 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: test-results
-        path:
-          - '**/elastic-serverless-forwarder-junit.xml'
-          - '**/coverage.xml'
+        path: |
+          **/elastic-serverless-forwarder-junit.xml
+          **/coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,6 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    permissions:
-      pull-requests: write # for marocchino/sticky-pull-request-comment
 
     steps:
 
@@ -43,13 +41,14 @@ jobs:
         python-version: '3.9' # As defined in tests/scripts/docker/run_tests.sh
         cache: 'pip'          # caching pip dependencies
 
-    - run: pip install -r requirements.txt -r requirements-tests.txt
+    - run: make all-requirements
 
     - run: make coverage
       env:
         # See https://github.com/elastic/elastic-serverless-forwarder/pull/280#issuecomment-1461554126
         AWS_ACCESS_KEY_ID: AWS_ACCESS_KEY_ID
         AWS_SECRET_ACCESS_KEY: AWS_SECRET_ACCESS_KEY
+        PYTEST_JUNIT: "--junitxml=./elastic-serverless-forwarder-junit.xml"
 
     - name: Store test results
       if: success() || failure()
@@ -57,58 +56,3 @@ jobs:
       with:
         name: test-results
         path: '**/elastic-serverless-forwarder-junit.xml'
-
-    - name: Code Coverage Summary Report
-      if: success() || failure()
-      uses: irongut/CodeCoverageSummary@v1.3.0
-      with:
-        filename: coverage.xml
-        format: 'markdown'
-        output: 'both'
-
-    - name: Store coverage results
-      if: success() || failure()
-      uses: actions/upload-artifact@v3
-      with:
-        name: coverage
-        path: |
-          coverage.xml
-          code-coverage-results.md
-
-    # Version https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.5.0
-    - name: Add Coverage PR Comment
-      uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd
-      if: github.event_name == 'pull_request' && (success() || failure())
-      with:
-        recreate: true
-        path: code-coverage-results.md
-
-    - name: Write to Job Summary
-      if: success() || failure()
-      run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
-
-  test-reporting:
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    permissions:
-      pull-requests: write # for marocchino/sticky-pull-request-comment
-    steps:
-    - run: curl https://raw.githubusercontent.com/irongut/CodeCoverageSummary/master/src/coverage.simplecov.xml > coverage.xml
-    - name: Code Coverage Summary Report
-      uses: irongut/CodeCoverageSummary@v1.3.0
-      with:
-        filename: coverage.xml
-        format: 'markdown'
-        output: 'both'
-    - name: Store coverage results
-      uses: actions/upload-artifact@v3
-      with:
-        name: coverage
-        path: |
-          coverage.xml
-          code-coverage-results.md
-    - name: Add Coverage PR Comment
-      uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd
-      with:
-        recreate: true
-        path: code-coverage-results.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,4 +55,6 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: test-results
-        path: '**/elastic-serverless-forwarder-junit.xml'
+        path:
+          - '**/elastic-serverless-forwarder-junit.xml'
+          - '**/coverage.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,3 +86,29 @@ jobs:
     - name: Write to Job Summary
       if: success() || failure()
       run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
+
+  test-reporting:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      pull-requests: write # for marocchino/sticky-pull-request-comment
+    steps:
+    - run: curl https://raw.githubusercontent.com/irongut/CodeCoverageSummary/master/src/coverage.simplecov.xml > coverage.xml
+    - name: Code Coverage Summary Report
+      uses: irongut/CodeCoverageSummary@v1.3.0
+      with:
+        filename: coverage.xml
+        format: 'markdown'
+        output: 'both'
+    - name: Store coverage results
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage
+        path: |
+          coverage.xml
+          code-coverage-results.md
+    - name: Add Coverage PR Comment
+      uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd
+      with:
+        recreate: true
+        path: code-coverage-results.md


### PR DESCRIPTION
Iterating on #281: I have no push permission on @v1v fork, so I've created a separate branch on my fork
## What does this PR do?

Enable coverage reporting and storing artifacts so they can be useful for debugging purposes.

## Why is it important?

Visualise the coverage as we used to have with Jenkins

Originally removed for required extra permissions -> https://github.com/elastic/elastic-serverless-forwarder/pull/223/commits/168d8022435f04f9cf9d879d21fefcfbf81da8ab#r1094793556