### PR TITLE
Fix make docker-lint

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -5,3 +5,4 @@ isort
 mypy
 types-PyYAML
 types-mock
+pyflakes<3.1.0,>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ aws_lambda_typing==2.17.0
 ujson==5.7.0
 requests==2.28.2
 urllib3<2,>=1.21.1
-pyflakes<3.1.0,>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ aws_lambda_typing==2.17.0
 ujson==5.7.0
 requests==2.28.2
 urllib3<2,>=1.21.1
+pyflakes<3.1.0,>=3.0.0

--- a/share/json.py
+++ b/share/json.py
@@ -8,7 +8,7 @@ import ujson
 
 
 def json_dumper(json_object: Any) -> str:
-    return ujson.dumps(json_object, ensure_ascii=False, reject_bytes=False)  # type:ignore
+    return ujson.dumps(json_object, ensure_ascii=False, reject_bytes=False)
 
 
 def json_parser(payload: AnyStr) -> Any:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to fix `make docker-lint` issue by forcing `pyflake` to `<3.1.0,>=3.0.0` instead of `<2.1.0,>=2.0.0`. 
Here is the original [error](https://github.com/elastic/elastic-serverless-forwarder/actions/runs/4852407533/jobs/8647354091?pr=351):
```
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.9/site-packages/flake8/checker.py", line 451, in run_check
    return plugin["plugin"](**arguments)
  File "/home/user/.local/lib/python3.9/site-packages/flake8/plugins/pyflakes.py", line 99, in __init__
    super(FlakesChecker, self).__init__(
  File "/home/user/.local/lib/python3.9/site-packages/pyflakes/checker.py", line 498, in __init__
    self.runDeferred(self._deferredFunctions)
  File "/home/user/.local/lib/python3.9/site-packages/pyflakes/checker.py", line 535, in runDeferred
    handler()
  File "/home/user/.local/lib/python3.9/site-packages/pyflakes/checker.py", line 1228, in runFunction
    self.handleNode(stmt, node)
  File "/home/user/.local/lib/python3.9/site-packages/pyflakes/checker.py", line 871, in handleNode
    handler(node)
  File "/home/user/.local/lib/python3.9/site-packages/pyflakes/checker.py", line 824, in handleChildren
    self.handleNode(node, tree)
  File "/home/user/.local/lib/python3.9/site-packages/pyflakes/checker.py", line 870, in handleNode
    handler = self.getNodeHandler(node.__class__)
  File "/home/user/.local/lib/python3.9/site-packages/pyflakes/checker.py", line 700, in getNodeHandler
    self._nodeHandlers[node_class] = handler = getattr(self, nodeType)
AttributeError: 'FlakesChecker' object has no attribute 'CONSTANT'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/usr/local/lib/python3.9/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/home/user/.local/lib/python3.9/site-packages/flake8/checker.py", line 682, in _run_checks
    return checker.run_checks()
  File "/home/user/.local/lib/python3.9/site-packages/flake8/checker.py", line 612, in run_checks
    self.run_ast_checks()
  File "/home/user/.local/lib/python3.9/site-packages/flake8/checker.py", line 513, in run_ast_checks
    checker = self.run_check(plugin, tree=ast)
  File "/home/user/.local/lib/python3.9/site-packages/flake8/checker.py", line 456, in run_check
    raise exceptions.PluginExecutionFailed(
  File "/home/user/.local/lib/python3.9/site-packages/flake8/exceptions.py", line 86, in __init__
    self.original_exception = kwargs.pop("exception")
KeyError: 'exception'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/user/.local/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/home/user/.local/lib/python3.9/site-packages/flake8/main/cli.py", line 16, in main
    app.run(argv)
  File "/home/user/.local/lib/python3.9/site-packages/flake8/main/application.py", line 412, in run
    self._run(argv)
  File "/home/user/.local/lib/python3.9/site-packages/flake8/main/application.py", line 400, in _run
    self.run_checks()
  File "/home/user/.local/lib/python3.9/site-packages/flake8/main/application.py", line 318, in run_checks
    self.file_checker_manager.run()
  File "/home/user/.local/lib/python3.9/site-packages/flake8_per_file_ignores.py", line 33, in run
    orig_run(self)
  File "/home/user/.local/lib/python3.9/site-packages/flake8/checker.py", line 338, in run
    self.run_parallel()
  File "/home/user/.local/lib/python3.9/site-packages/flake8/checker.py", line 302, in run_parallel
    for ret in pool_map:
  File "/usr/local/lib/python3.9/multiprocessing/pool.py", line 448, in <genexpr>
    return (item for chunk in result for item in chunk)
  File "/usr/local/lib/python3.9/multiprocessing/pool.py", line 870, in next
    raise value
KeyError: 'exception'
make: *** [Makefile:31: flake8] Error 1
```



## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
