### PR TITLE
Adding prefix option for IAM ROLE/POLICY

### DIFF
--- a/publish_lambda.sh
+++ b/publish_lambda.sh
@@ -106,7 +106,7 @@ Resources:
                         - lambda.amazonaws.com
                     Action:
                       - 'sts:AssumeRole'
-              RoleName: !Sub "${PREFIX}ApplicationElasticServerlessForwarderRole"
+              RoleName: !Sub "${CUSTOM_ROLE_PREFIX}ApplicationElasticServerlessForwarderRole"
               ManagedPolicyArns:
                 - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
                 - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
@@ -318,7 +318,7 @@ def create_policy(publish_config: dict[str, Any]):
                 "Fn::Join": [
                     "-",
                     [
-                        "${PREFIX}elastic-serverless-forwarder-policy",
+                        "${CUSTOM_ROLE_PREFIX}elastic-serverless-forwarder-policy",
                         {
                             "Fn::Select": [
                                 4,

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,7 +4,7 @@ pytest-cov==4.0.0
 pytest-benchmark==4.0.0
 coverage==7.2.7
 simplejson==3.19.1
-orjson==3.8.12
+orjson==3.8.14
 pysimdjson==5.0.2
 python-rapidjson==1.10
 cysimdjson==21.11


### PR DESCRIPTION
## What does this PR do?
This changes would add an option to specify the user to customise the IAM role/policy name created during direct deployment

## Why is it important?
Naming conventions of IAM Roles/policy will not be a hindrance to use this.

## Checklist
- [x ] My code follows the style guidelines of this project
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

