### PR TITLE
[DOCS] Mention that ESF may result in additional charges

### DIFF
--- a/docs/en/aws-elastic-serverless-forwarder.asciidoc
+++ b/docs/en/aws-elastic-serverless-forwarder.asciidoc
@@ -15,6 +15,7 @@ The Elastic Serverless Forwarder works with {stack} 7.16 and later.
 
 IMPORTANT: Using Elastic Serverless Forwarder may result in additional charges
 on your next cloud provider billing statement due to increased usage. To learn
+IMPORTANT: Using Elastic Serverless Forwarder may result in additional charges. To learn
 how to minimize additional charges, refer to <<preventing-unexpected-costs>>.
 
 [discrete]

--- a/docs/en/aws-elastic-serverless-forwarder.asciidoc
+++ b/docs/en/aws-elastic-serverless-forwarder.asciidoc
@@ -13,6 +13,10 @@ The Elastic Serverless Forwarder is an Amazon Web Services ({aws}) Lambda functi
 
 The Elastic Serverless Forwarder works with {stack} 7.16 and later.
 
+IMPORTANT: Using Elastic Serverless Forwarder may result in additional charges
+on your next cloud provider billing statement due to increased usage. To learn
+how to minimize additional charges, refer to <<preventing-unexpected-costs>>.
+
 [discrete]
 [[aws-serverless-forwarder-overview]]
 = Overview

--- a/docs/en/aws-elastic-serverless-forwarder.asciidoc
+++ b/docs/en/aws-elastic-serverless-forwarder.asciidoc
@@ -13,8 +13,6 @@ The Elastic Serverless Forwarder is an Amazon Web Services ({aws}) Lambda functi
 
 The Elastic Serverless Forwarder works with {stack} 7.16 and later.
 
-IMPORTANT: Using Elastic Serverless Forwarder may result in additional charges
-on your next cloud provider billing statement due to increased usage. To learn
 IMPORTANT: Using Elastic Serverless Forwarder may result in additional charges. To learn
 how to minimize additional charges, refer to <<preventing-unexpected-costs>>.
 

--- a/docs/en/aws-serverless-troubleshooting.asciidoc
+++ b/docs/en/aws-serverless-troubleshooting.asciidoc
@@ -20,6 +20,7 @@ NOTE: For example, if you don't increase the visibility timeout for an SQS queue
 If the Elastic Serverless Forwarder is attached to a VPC, you need to https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html[create VPC Endpoints] for S3 and SQS, and for *every* service you define as an input for the forwarder. S3 and SQS VPC Endpoints are always required for reading the `config.yaml` uploaded to S3 and managing the _Continuing queue_ and the _Replay queue_, regardless of the <<aws-serverless-forwarder-inputs>> used.
 
 [discrete]
+[[preventing-unexpected-costs]]
 == Preventing unexpected costs
 It is important to monitor the Elastic Serverless Forwarder Lambda function for timeouts to prevent unexpected costs. You can use the https://docs.elastic.co/en/integrations/aws/lambda[AWS Lambda integration] for this. If the timeouts are constant, you should throttle the Lambda function to stop its execution before proceeding with any troubleshooting steps. In most cases, constant timeouts will cause the records and messages from the event triggers to go back to their sources and trigger the function again, which will cause further timeouts and force a loop that will incure unexpected high costs. For more information on throttling Lambda functions, refer to https://docs.aws.amazon.com/lambda/latest/operatorguide/throttling.html[AWS docs].
 


### PR DESCRIPTION
## What does this PR do?
Adds a statement to the overview page in the ESF docs:

![image](https://github.com/elastic/elastic-serverless-forwarder/assets/14206422/48d8bfd4-328d-495d-9efe-9d14f60694aa)

Note that I decided not to put this statement on the index page most users don't see the index page (google sends them to the overview).

## Why is it important?

Users need to know in advance if they are doing something that might result in additional charges.

## Checklist

- [x] My code follows the style guidelines of this project

## Related issues

- Closes #444