### PR TITLE
Remove installing netcat and openjdk-11-jdk

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -6,8 +6,6 @@ RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install \
     curl \
     docker.io \
     libsasl2-dev \
-    netcat \
-    openjdk-11-jdk \
     sudo \
     zip &&\
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to remove netcat and openjdk-11-jdk installation to fix `make docker-lint` error:
```
 => ERROR [ 2/14] RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install     ca-certificates     curl     docker.io     libsasl2-dev     netcat     openjdk-11-jdk     sudo     zip &&    rm -r  2.9s
------
 > [ 2/14] RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install     ca-certificates     curl     docker.io     libsasl2-dev     netcat     openjdk-11-jdk     sudo     zip &&    rm -rf /var/lib/apt/lists/*:
2.886 E: Package 'netcat' has no installation candidate
2.886 E: Unable to locate package openjdk-11-jdk
------
Dockerfile:4
--------------------
   3 |     
   4 | >>> RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install \
   5 | >>>     ca-certificates \
   6 | >>>     curl \
   7 | >>>     docker.io \
   8 | >>>     libsasl2-dev \
   9 | >>>     netcat \
  10 | >>>     openjdk-11-jdk \
  11 | >>>     sudo \
  12 | >>>     zip &&\
  13 | >>>     rm -rf /var/lib/apt/lists/*
  14 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get -qq update && apt-get -qq -y --no-install-recommends install     ca-certificates     curl     docker.io     libsasl2-dev     netcat     openjdk-11-jdk     sudo     zip &&    rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
make: *** [flake8] Error 1
```