### PR TITLE
Remove LocationConstraint when running create-bucket s3 api call

### DIFF
--- a/.internal/aws/scripts/dist.sh
+++ b/.internal/aws/scripts/dist.sh
@@ -35,7 +35,7 @@ CODE_URI="${TMPDIR}/sources"
 
 trap "rm -rf ${TMPDIR}" EXIT
 
-aws s3api get-bucket-location --bucket "${BUCKET}" --region "${REGION}" || aws s3api create-bucket --acl private --bucket "${BUCKET}" --region "${REGION}" --create-bucket-configuration LocationConstraint="${REGION}"
+aws s3api get-bucket-location --bucket "${BUCKET}" --region "${REGION}" || aws s3api create-bucket --acl private --bucket "${BUCKET}" --region "${REGION}" --create-bucket-configuration LocationConstraint="${REGION}" || aws s3api create-bucket --acl private --bucket "${BUCKET}" --region "${REGION}"
 
 # Check if region is in AWS GovCloud and create bucket arn
 if [[ "${REGION}" == *gov* ]]; then


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

When REGION equals to us-east-1, which is the default region, adding `LocationConstraint` when calling `aws s3api create-bucket` will fail. This PR is to add the option of running the create bucket API call without the `--create-bucket-configuration LocationConstraint`. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`


