### PR TITLE
docs: update link to documentation

### DIFF
--- a/docs/README-AWS.md
+++ b/docs/README-AWS.md
@@ -2,7 +2,7 @@
 
 The Elastic Serverless Forwarder is an Amazon Web Services (AWS) Lambda function that ships logs from an AWS environment to Elastic.
 
-Please refer to the official [Elastic documentation for Elastic Serverless Forwarder](https://www.elastic.co/guide/en/observability/master/aws-elastic-serverless-forwarder.html) for detailed instructions on how to deploy and configure the forwarder.
+Please refer to the official [Elastic documentation for Elastic Serverless Forwarder](https://www.elastic.co/guide/en/esf/master/aws-elastic-serverless-forwarder.html) for detailed instructions on how to deploy and configure the forwarder.
 
 ## Overview
 


### PR DESCRIPTION
The former page is outdated and mentions to go to a different page
instead.

Update the original link reference to the correct page and skip the
intermediate one.

fixes 664
