### PR TITLE
[Github workflow] Add new tag on version.py update

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,37 @@
+---
+## Workflow to check CHANGELOG was updated when version gets updated in share/version.py
+name: changelog
+
+on:
+  pull_request:
+    paths:
+      - 'share/version.py'
+
+jobs:
+
+  changelog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - name: Get version number
+        shell: bash
+        run: |
+          VERSION=$(awk '/version/ {print $3}' share/version.py | tr -d '"')
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "::notice::ESF version is $VERSION."
+
+      - name: Check changelog
+        shell: bash
+        run: |
+          first_line=$(awk 'NR==1' CHANGELOG.md)
+
+          if [[ $first_line != *" v${{ env.VERSION }} "* ]]; then
+            error="CHANGELOG should contain the new version in its first line, like this ' v1.1.1 '."
+            reminder="Do not forget to add space before and after the version in the CHANGELOG first line."
+            echo "::error::$error $reminder"
+            exit 1
+          fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get version number
         shell: bash
         run: |
-          VERSION=$(awk '/version/ {print $3}' share/version.py | tr -d '"')
+          VERSION=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+(\-[a-zA-Z]+[0-9]+)?' share/version.py)
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "::notice::ESF version is $VERSION."
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+---
+## Workflow to create a new git tag if version.py variable version gets updated
+name: release
+
+permissions:
+  contents: write # write permission is required to create a GitHub release
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'share/version.py'
+
+jobs:
+
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Get version number
+      shell: bash
+      run: |
+        VERSION=$(awk '/version/ {print $3}' version.py | tr -d '"')
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+    - name: Create tag
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.git.createRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: 'refs/tags/lambda-v' + ${{ env.VERSION }},
+            sha: context.sha
+          })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,9 @@ jobs:
     - name: Get version number
       shell: bash
       run: |
-        VERSION=$(awk '/version/ {print $3}' share/version.py | tr -d '"')
+        VERSION=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+(\-[a-zA-Z]+[0-9]+)?' share/version.py)
         echo "VERSION=${VERSION}" >> $GITHUB_ENV
+        echo "::notice::ESF version is $VERSION."
 
     - name: Create tag
       uses: actions/github-script@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Get version number
       shell: bash
       run: |
-        VERSION=$(awk '/version/ {print $3}' version.py | tr -d '"')
+        VERSION=$(awk '/version/ {print $3}' share/version.py | tr -d '"')
         echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
     - name: Create tag

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,5 @@
 mock==5.1.0
-pytest==8.1.1
+pytest==7.4.4
 pytest-cov==4.1.0
 pytest-benchmark==4.0.0
 coverage==7.4.1

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,5 @@
 mock==5.1.0
-pytest==7.4.4
+pytest==8.1.1
 pytest-cov==4.1.0
 pytest-benchmark==4.0.0
 coverage==7.4.1


### PR DESCRIPTION
## What does this PR do?

It adds two GitHub actions workflows:
- `changelog`: when `version.py` is updated on a pull request, it will check if `CHANGELOG` has the first line with `* v$VERSION*`
- `release`: When `share/version.py` gets pushed, it will automatically create a new tag named `lambda-v{VERSION}`.

## Why is it important?

It automates the tag process as mentioned in https://github.com/elastic/elastic-serverless-forwarder/issues/540.

With this workflow, we can also create a new workflow to zip dependencies on a new tag creation like mentioned in the issue https://github.com/elastic/elastic-serverless-forwarder/issues/683.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`


## Related issues

- Relates https://github.com/elastic/elastic-serverless-forwarder/issues/540.
- Relates https://github.com/elastic/elastic-serverless-forwarder/issues/683.



