### PR TITLE
Upload dependencies to S3 bucket on new tag release

### DIFF
--- a/.github/workflows/upload-dependencies.yml
+++ b/.github/workflows/upload-dependencies.yml
@@ -1,0 +1,66 @@
+---
+## Workflow to push zip with dependencies to S3 bucket every time the ESF version is updated
+name: upload-dependencies
+
+env:
+  BUCKET_NAME : "esf-dependencies"
+  AWS_REGION : "eu-central-1"
+  ROLE: "arn:aws:iam::267093732750:role/esf-dependencies-role"
+
+
+on:
+  workflow_run:
+    workflows: [release]
+    types:
+      - completed
+
+
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
+
+jobs:
+
+  build-and-upload-dependencies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      # See https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-create-dependencies
+
+      - uses: actions/checkout@v4
+
+      - name: Get version number
+        shell: bash
+        run: |
+          VERSION=$(awk '/version/ {print $3}' version.py | tr -d '"')
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: 'pip'          # caching pip dependencies
+
+      - name: Install requirements in a directory and zip it.
+        shell: bash
+        run: |
+          pip3 install -r requirements.txt -t ./dependencies
+          cd dependencies && zip -r ../lambda-v${{ env.VERSION }}.zip .
+
+      - name: Place handlers in the zip file.
+        shell: bash
+        run: |
+          zip -r ./lambda-v${{ env.VERSION }}.zip main_aws.py
+          zip -r ./lambda-v${{ env.VERSION }}.zip handlers
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Copy file to s3
+        run: |
+          aws s3 cp ./lambda-v${{ env.VERSION }}.zip s3://${{ env.BUCKET_NAME }}/
+

--- a/.github/workflows/upload-dependencies.yml
+++ b/.github/workflows/upload-dependencies.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Get version number
         shell: bash
         run: |
-          VERSION=$(awk '/version/ {print $3}' version.py | tr -d '"')
+          VERSION=$(awk '/version/ {print $3}' share/version.py | tr -d '"')
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/upload-dependencies.yml
+++ b/.github/workflows/upload-dependencies.yml
@@ -34,8 +34,9 @@ jobs:
       - name: Get version number
         shell: bash
         run: |
-          VERSION=$(awk '/version/ {print $3}' share/version.py | tr -d '"')
+          VERSION=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+(\-[a-zA-Z]+[0-9]+)?' share/version.py)
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "::notice::ESF version is $VERSION."
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## What does this PR do?

Uploads dependencies to S3 bucket on new tag release.

This workflow is dependent on workflow `release` - that is, it waits for the new release to zip all the dependencies and send it to S3 bucket.

You can see more details discussed in issue https://github.com/elastic/elastic-serverless-forwarder/issues/683.


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`


## Related issues

Closes https://github.com/elastic/elastic-serverless-forwarder/issues/683.
