### PR TITLE
Add new dependencies to zip files: share, shippers and storage

### DIFF
--- a/.github/workflows/upload-dependencies.yml
+++ b/.github/workflows/upload-dependencies.yml
@@ -54,6 +54,9 @@ jobs:
         run: |
           zip -r ./lambda-v${{ env.VERSION }}.zip main_aws.py
           zip -r ./lambda-v${{ env.VERSION }}.zip handlers
+          zip -r ./lambda-v${{ env.VERSION }}.zip share
+          zip -r ./lambda-v${{ env.VERSION }}.zip storage
+          zip -r ./lambda-v${{ env.VERSION }}.zip shippers
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## What does this PR do?

When building the zip file of the dependencies, we also add:
- share
- storage
- shippers

This is needed because the handlers are importing these. Otherwise the ESF lambda function will fail.


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`


## How to test this PR locally

You can run the step commands locally, and it should work fine.

## Issues

Relates to https://github.com/elastic/elastic-serverless-forwarder/issues/683.
