### PR TITLE
Place messages from misconfigured IDs in the replay queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### v1.14.0 - 2024/05/07
+##### Features
+...
+##### Bug fixes
+...
+
 ### v1.13.1 - 2024/03/07
 ##### Features
 * Add documentation and optimise performance for `root_fields_to_add_to_expanded_event` [#642](https://github.com/elastic/elastic-serverless-forwarder/pull/642)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 ### v1.14.0 - 2024/05/07
-##### Features
-...
 ##### Bug fixes
-...
+* Report misconfigured input ids as an error instead of warning, and place those messages in the replaying queue [#711](https://github.com/elastic/elastic-serverless-forwarder/pull/711).
 
 ### v1.13.1 - 2024/03/07
 ##### Features

--- a/handlers/aws/handler.py
+++ b/handlers/aws/handler.py
@@ -13,13 +13,13 @@ from shippers import EVENT_IS_FILTERED, EVENT_IS_SENT, CompositeShipper
 
 from .cloudwatch_logs_trigger import (
     _from_awslogs_data_to_event,
-    _handle_cloudwatch_logs_move,
     _handle_cloudwatch_logs_event,
+    _handle_cloudwatch_logs_move,
 )
 from .kinesis_trigger import _handle_kinesis_move, _handle_kinesis_record
 from .replay_trigger import ReplayedEventReplayHandler, get_shipper_for_replay_event
-from .s3_sqs_trigger import _handle_s3_sqs_move, _handle_s3_sqs_event
-from .sqs_trigger import handle_sqs_move, _handle_sqs_event
+from .s3_sqs_trigger import _handle_s3_sqs_event, _handle_s3_sqs_move
+from .sqs_trigger import _handle_sqs_event, handle_sqs_move
 from .utils import (
     CONFIG_FROM_PAYLOAD,
     INTEGRATION_SCOPE_GENERIC,

--- a/handlers/aws/handler.py
+++ b/handlers/aws/handler.py
@@ -229,8 +229,12 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
         composite_shipper.flush()
         shared_logger.info(
             "lambda processed all the events",
-            extra={"sent_events": sent_events, "empty_events": empty_events, "skipped_events": skipped_events,
-                   "error_events": error_events},
+            extra={
+                "sent_events": sent_events,
+                "empty_events": empty_events,
+                "skipped_events": skipped_events,
+                "error_events": error_events,
+            },
         )
 
     if trigger_type == "kinesis-data-stream":
@@ -330,8 +334,12 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
         composite_shipper.flush()
         shared_logger.info(
             "lambda processed all the events",
-            extra={"sent_events": sent_events, "empty_events": empty_events, "skipped_events": skipped_events,
-                   "error_events": error_events},
+            extra={
+                "sent_events": sent_events,
+                "empty_events": empty_events,
+                "skipped_events": skipped_events,
+                "error_events": error_events,
+            },
         )
 
     if trigger_type == "s3-sqs" or trigger_type == "sqs":
@@ -553,8 +561,12 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
 
         shared_logger.info(
             "lambda processed all the events",
-            extra={"sent_events": sent_events, "empty_events": empty_events, "skipped_events": skipped_events,
-                   "error_events": error_events},
+            extra={
+                "sent_events": sent_events,
+                "empty_events": empty_events,
+                "skipped_events": skipped_events,
+                "error_events": error_events,
+            },
         )
 
     return "completed"

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -397,6 +397,9 @@ def get_input_from_log_group_subscription_data(
     all_regions = get_ec2_client().describe_regions(AllRegions=True)
     assert "Regions" in all_regions
     for region_data in all_regions["Regions"]:
+
+        # arn:aws:logs:region:account-id:log-group:log_group_name:*
+
         region = region_data["RegionName"]
 
         aws_or_gov = "aws"
@@ -418,7 +421,7 @@ def get_input_from_log_group_subscription_data(
         if event_input is not None:
             return log_group_arn, event_input
 
-    return "", None
+    return f"arn:aws:logs:%AWS_REGION%:{account_id}:log-group:{log_group_name}:*", None
 
 
 def delete_sqs_record(sqs_arn: str, receipt_handle: str) -> None:

--- a/how-to-test-locally/.env
+++ b/how-to-test-locally/.env
@@ -1,0 +1,11 @@
+# List of requirement files.
+# Split them with , and without space, like this: example1.txt,example2.txt
+REQUIREMENTS=requirements.txt
+
+# List of python files/directories to add to the zip file.
+# Split them with , and without space, like this: example1.txt,example2.txt
+DEPENDENCIES=main_aws.py,handlers,share,storage,shippers
+
+# Zip filename
+FILENAME=local_esf.zip
+

--- a/how-to-test-locally/README.md
+++ b/how-to-test-locally/README.md
@@ -8,6 +8,8 @@ This is just an example of how to build and run ESF locally.
 
 ## Steps
 
+**Important note**: ESF dependencies have been testing on architecture `x86_64`. Make sure to use it as well.
+
 ### Step 1: Build your dependencies zip file
 
 You can build your own, or you can choose to run:

--- a/how-to-test-locally/README.md
+++ b/how-to-test-locally/README.md
@@ -1,0 +1,64 @@
+This is just an example of how to build and run ESF locally.
+
+## Requirements
+
+- [Terraform](https://www.terraform.io/)
+- (Optional) [Taskfile](https://taskfile.dev/installation/)
+
+
+## Steps
+
+### Step 1: Build your dependencies zip file
+
+You can build your own, or you can choose to run:
+```bash
+task
+```
+To build it automatically.
+
+You can update the task variables in the `.env` file:
+- The list of python dependencies, `DEPENDENCIES`.
+- The list of python requirement files, `REQUIREMENTS`.
+- The name of the zip file, `FILENAME`.
+
+
+### Step 2: Run ESF terraform
+
+Use the code in [ESF terraform repository](https://github.com/elastic/terraform-elastic-esf).
+
+Place your `local_esf.zip` (or `<FILENAME>` if you changed the value) in the same directory as ESF terraform.
+
+Go to `esf.tf` file and edit:
+
+```terraform
+locals {
+  ...
+  dependencies-file = "local_esf.zip" # value of FILENAME in .env
+  ...
+}
+```
+
+Remove/comment these lines from `esf.tf` file:
+
+```terraform
+#resource "terraform_data" "curl-dependencies-zip" {
+#  provisioner "local-exec" {
+#    command = "curl -L -O ${local.dependencies-bucket-url}/${local.dependencies-file}"
+#  }
+#}
+```
+
+And fix the now missing dependency in `dependencies-file`:
+
+```terraform
+resource "aws_s3_object" "dependencies-file" {
+  bucket = local.config-bucket-name
+  key    = local.dependencies-file
+  source = local.dependencies-file
+
+  depends_on = [aws_s3_bucket.esf-config-bucket] #, terraform_data.curl-dependencies-zip]
+}
+```
+
+Now follow the README file from [ESF terraform repository](https://github.com/elastic/terraform-elastic-esf) on how to configure the remaining necessary variables. You will have to configure `release-version` variable, but it will not be relevant to this. You can set any value you want for it.
+

--- a/how-to-test-locally/README.md
+++ b/how-to-test-locally/README.md
@@ -8,7 +8,7 @@ This is just an example of how to build and run ESF locally.
 
 ## Steps
 
-**Important note**: ESF dependencies have been testing on architecture `x86_64`. Make sure to use it as well.
+**Important note**: ESF dependencies have been tested on architecture `x86_64`. Make sure to use it as well.
 
 ### Step 1: Build your dependencies zip file
 
@@ -27,6 +27,9 @@ You can update the task variables in the `.env` file:
 ### Step 2: Run ESF terraform
 
 Use the code in [ESF terraform repository](https://github.com/elastic/terraform-elastic-esf).
+
+> **NOTE**: ESF lambda function is using architecture `x86_64`.
+
 
 Place your `local_esf.zip` (or `<FILENAME>` if you changed the value) in the same directory as ESF terraform.
 

--- a/how-to-test-locally/Taskfile.yaml
+++ b/how-to-test-locally/Taskfile.yaml
@@ -1,0 +1,49 @@
+version: '3'
+
+env:
+    # Directory to place the dependencies - just internal to this taskfile
+    DIR: dependencies
+
+dotenv: ['.env']
+
+tasks:
+    default:
+        cmds:
+            - task: install-requirements
+            - task: build-zip-file
+            - task: remove-dependencies-dir
+            - task: add-to-zip
+
+    install-requirements:
+        desc: "Install requirements from $REQUIREMENTS."
+        internal: true
+        requires:
+            var: REQUIREMENTS
+        cmds:
+            - rm -rf $DIR
+            - for:
+                var: REQUIREMENTS
+                split: ','
+              cmd: pip3.9 install -r ../{{ .ITEM }} -t $DIR
+
+    build-zip-file:
+        desc: "Zip $DIR to build $FILENAME."
+        internal: true
+        cmds:
+            - rm -rf $FILENAME
+            - cd $DIR && zip -r ../$FILENAME .
+
+    remove-dependencies-dir:
+        desc: "Delete $DIR."
+        internal: true
+        cmds:
+            - rm -rf $DIR
+
+    add-to-zip:
+        desc: "Add $DEPENDENCIES to zip file."
+        internal: true
+        cmds:
+            - for:
+                var: DEPENDENCIES
+                split: ','
+              cmd: zip -r $FILENAME ../{{ .ITEM }}

--- a/share/version.py
+++ b/share/version.py
@@ -2,4 +2,4 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-version = "1.13.1"
+version = "1.14.0"

--- a/tests/handlers/aws/test_handler.py
+++ b/tests/handlers/aws/test_handler.py
@@ -399,8 +399,8 @@ class TestLambdaHandlerNoop(TestCase):
         with self.subTest("no originalEventSourceARN in messageAttributes"):
             ctx = ContextMock()
             os.environ["S3_CONFIG_FILE"] = "s3://s3_config_file_bucket/s3_config_file_object_key"
-            os.environ["SQS_REPLAY_URL"] = "https://sqs.us-east-2.amazonaws.com/123456789012/replay_queue"
-            os.environ["SQS_CONTINUE_URL"] = "https://sqs.us-east-2.amazonaws.com/123456789012/continue_queue"
+            os.environ["SQS_REPLAY_URL"] = "https://sqs.eu-central-1.amazonaws.com/123456789012/replay_queue"
+            os.environ["SQS_CONTINUE_URL"] = "https://sqs.eu-central-1.amazonaws.com/123456789012/continue_queue"
             lambda_event = deepcopy(_dummy_lambda_event)
             del lambda_event["Records"][0]["messageAttributes"]["originalEventSourceARN"]
             assert handler(lambda_event, ctx) == "completed"  # type:ignore

--- a/tests/handlers/aws/test_handler.py
+++ b/tests/handlers/aws/test_handler.py
@@ -399,6 +399,8 @@ class TestLambdaHandlerNoop(TestCase):
         with self.subTest("no originalEventSourceARN in messageAttributes"):
             ctx = ContextMock()
             os.environ["S3_CONFIG_FILE"] = "s3://s3_config_file_bucket/s3_config_file_object_key"
+            os.environ["SQS_REPLAY_URL"] = "https://sqs.us-east-2.amazonaws.com/123456789012/replay_queue"
+            os.environ["SQS_CONTINUE_URL"] = "https://sqs.us-east-2.amazonaws.com/123456789012/continue_queue"
             lambda_event = deepcopy(_dummy_lambda_event)
             del lambda_event["Records"][0]["messageAttributes"]["originalEventSourceARN"]
             assert handler(lambda_event, ctx) == "completed"  # type:ignore
@@ -460,20 +462,6 @@ class TestLambdaHandlerNoop(TestCase):
             lambda_event["Records"][0]["eventSource"] = "dummy"
             lambda_event["Records"][0]["eventSourceARN"] = "arn:aws:dummy:eu-central-1:123456789:input"
             del lambda_event["Records"][0]["messageAttributes"]["originalEventSourceARN"]
-            assert handler(lambda_event, ctx) == "completed"  # type:ignore
-
-        with self.subTest("no input defined for kinesis-data-stream"):
-            ctx = ContextMock()
-            os.environ["S3_CONFIG_FILE"] = "s3://s3_config_file_bucket/s3_config_file_object_key"
-            lambda_event = {
-                "Records": [
-                    {
-                        "eventSource": "aws:kinesis",
-                        "kinesis": {"data": ""},
-                        "eventSourceARN": "arn:aws:kinesis:eu-central-1:123456789:stream/test-esf-kinesis-stream",
-                    }
-                ]
-            }
             assert handler(lambda_event, ctx) == "completed"  # type:ignore
 
         with self.subTest("body is neither replay queue nor s3-sqs"):

--- a/tests/handlers/aws/test_integrations.py
+++ b/tests/handlers/aws/test_integrations.py
@@ -3247,7 +3247,10 @@ class TestLambdaHandlerIntegration(TestCase):
         assert len(messages_sqs) == 3
         assert len(replayed_messages) == 3
         for i, message in enumerate(replayed_messages):
-            assert messages_sqs[i]["eventSourceARN"] == message["messageAttributes"]["originalEventSourceARN"]["stringValue"]
+            assert (
+                messages_sqs[i]["eventSourceARN"]
+                == message["messageAttributes"]["originalEventSourceARN"]["stringValue"]
+            )
 
     def test_sqs_last_ending_offset_reset(self) -> None:
         assert isinstance(self.logstash, LogstashContainer)


### PR DESCRIPTION
## What does this PR do?

Prints error message if the input id from the trigger is not present in `config.yaml`, and places the message in the replay queue.


## Why is this PR important?

Issues linked explained it well, but to sum it up:
- If the ID in the `config.yaml` is set incorrectly, but ESF is associated with the right trigger inputs ids (read next section to get better understanding on how this can happen), we should print an error that the ID is not present in the `config.yaml` so there is no output available for it. This way, all these messages will go to the replay queue, and we will count these events as `error_events`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md`


## How to test this PR locally

I added a `how-to-test` directory in the commits. Please follow the README.md file from that directory.
**Important: You need to use it with the code from [this PR](https://github.com/elastic/terraform-elastic-esf/pull/7) that is currently not merged, otherwise it will fail.**

I also added some tests to check the undefined input that will run in one of the GitHub workflows.

## Related issues

- Closes https://github.com/elastic/enhancements/issues/21296
- Closes https://github.com/elastic/elastic-serverless-forwarder/issues/696


## Tests and Results

#### SQS trigger

`config.yaml` looks like this:
```yaml
"inputs":
- "id": "arn:aws:sqs:eu-west-2:627286350134:wrong-sqs"
  "outputs":
  - "args":
      "api_key": "..."
      "elasticsearch_url": "..."
      "es_datastream_name": "logs-esf.sqs-default"
    "type": "elasticsearch"
  "type": "sqs"
```

And ESF has `aws_lambda_event_source_mapping` configured correctly with the SQS ARN.

<details>
<summary>ESF logs. To make it easier, I annotated the logs with <code><-</code> in the relevant lines.</summary>

```log
INIT_START Runtime Version: python:3.9.v51	Runtime Version ARN: arn:aws:lambda:eu-west-2::runtime:415294d499803f2ba2e75d2753b4523c4517c1c13e55d8ca19a44434f6cbb9a5
{
    "@timestamp": "2024-05-07T10:27:19.154Z",
    "log.level": "info",
    "message": "Found credentials in environment variables.",
    "ecs": {
        "version": "1.6.0"
    },
    "log": {
        "logger": "botocore.credentials",
        "origin": {
            "file": {
                "line": 1147,
                "name": "credentials.py"
            },
            "function": "load"
        },
        "original": "Found credentials in environment variables."
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 139802417399616,
            "name": "MainThread"
        }
    }
}

START RequestId: 85df0f38-3743-527e-8126-518c3377948d Version: $LATEST
{
    "@timestamp": "2024-05-07T10:27:19.320Z",
    "log.level": "info",
    "message": "trigger",
    "ecs": {
        "version": "1.6.0"
    },
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 56,
                "name": "handler.py"
            },
            "function": "lambda_handler"
        },
        "original": "trigger"
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 139802417399616,
            "name": "MainThread"
        }
    },
    "type": "sqs"
}

{
    "@timestamp": "2024-05-07T10:27:19.320Z",
    "log.level": "info",
    "message": "config file",
    "bucket_name": "constanca-test-esf-config-bucket",
    "ecs": {
        "version": "1.6.0"
    },
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 204,
                "name": "utils.py"
            },
            "function": "config_yaml_from_s3"
        },
        "original": "config file"
    },
    "object_key": "config.yaml",
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 139802417399616,
            "name": "MainThread"
        }
    }
}

{
    "@timestamp": "2024-05-07T10:27:19.818Z",
    "log.level": "info",
    "message": "trigger",
    "ecs": {
        "version": "1.6.0"
    },
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 338,
                "name": "handler.py"
            },
            "function": "lambda_handler"
        },
        "original": "trigger"
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 139802417399616,
            "name": "MainThread"
        }
    },
    "size": 1
}

{
    "@timestamp": "2024-05-07T10:27:19.819Z",
    "log.level": "error", 1, <------------------ FIXED
    "message": "no input defined",
    "ecs": {
        "version": "1.6.0"
    },
    "input_id": "arn:aws:sqs:eu-west-2:627286350134:constanca-esf-issue-696",
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 428,
                "name": "handler.py"
            },
            "function": "lambda_handler"
        },
        "original": "no input defined"
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 139802417399616,
            "name": "MainThread"
        }
    }
}

{
    "@timestamp": "2024-05-07T10:27:20.035Z",
    "log.level": "info",
    "message": "lambda processed all the events",
    "ecs": {
        "version": "1.6.0"
    },
    "empty_events": 0,
    "error_events": 1, <------------------ NEW
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 554,
                "name": "handler.py"
            },
            "function": "lambda_handler"
        },
        "original": "lambda processed all the events"
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 139802417399616,
            "name": "MainThread"
        }
    },
    "sent_events": 0,
    "skipped_events": 0
}

END RequestId: 85df0f38-3743-527e-8126-518c3377948d
REPORT RequestId: 85df0f38-3743-527e-8126-518c3377948d	Duration: 738.26 ms	Billed Duration: 739 ms	Memory Size: 128 MB	Max Memory Used: 89 MB	Init Duration: 707.29 ms
```

</details>

The replaying queue, `constanca-test-esf-replay-queue`, has `Messages available: 1`.

### Cloudwatch logs trigger


`config.yaml` looks like this:
```yaml
"inputs":
- "id": "arn:aws:logs:eu-west-2:627286350134:log-group:wrong-log-group:*"
  "outputs":
  - "args":
      "api_key": "..."
      "elasticsearch_url": "..."
      "es_datastream_name": "logs-esf.cloudwatchlogs-default"
    "type": "elasticsearch"
  "type": "cloudwatch-logs"
```

And ESF has `aws_cloudwatch_log_subscription_filter` configured correctly with the Cloudwatch Logs ARN.

<details>
<summary>ESF logs. To make it easier, I annotated the logs with <code><-</code> in the relevant lines.</summary>

```log
INIT_START Runtime Version: python:3.9.v51	Runtime Version ARN: arn:aws:lambda:eu-west-2::runtime:415294d499803f2ba2e75d2753b4523c4517c1c13e55d8ca19a44434f6cbb9a5
{
    "@timestamp": "2024-05-07T10:46:12.197Z",
    "log.level": "info",
    "message": "Found credentials in environment variables.",
    "ecs": {
        "version": "1.6.0"
    },
    "log": {
        "logger": "botocore.credentials",
        "origin": {
            "file": {
                "line": 1147,
                "name": "credentials.py"
            },
            "function": "load"
        },
        "original": "Found credentials in environment variables."
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 140459008206656,
            "name": "MainThread"
        }
    }
}

START RequestId: e5adae49-87f2-4b3d-a504-a67cc7aaa421 Version: $LATEST
{
    "@timestamp": "2024-05-07T10:46:12.360Z",
    "log.level": "info",
    "message": "trigger",
    "ecs": {
        "version": "1.6.0"
    },
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 56,
                "name": "handler.py"
            },
            "function": "lambda_handler"
        },
        "original": "trigger"
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 140459008206656,
            "name": "MainThread"
        }
    },
    "type": "cloudwatch-logs"
}

{
    "@timestamp": "2024-05-07T10:46:12.360Z",
    "log.level": "info",
    "message": "config file",
    "bucket_name": "constanca-test-esf-config-bucket",
    "ecs": {
        "version": "1.6.0"
    },
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 204,
                "name": "utils.py"
            },
            "function": "config_yaml_from_s3"
        },
        "original": "config file"
    },
    "object_key": "config.yaml",
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 140459008206656,
            "name": "MainThread"
        }
    }
}

{
    "@timestamp": "2024-05-07T10:46:12.830Z",
    "log.level": "info",
    "message": "trigger",
    "ecs": {
        "version": "1.6.0"
    },
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 141,
                "name": "handler.py"
            },
            "function": "lambda_handler"
        },
        "original": "trigger"
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 140459008206656,
            "name": "MainThread"
        }
    },
    "size": 1
}

{
    "@timestamp": "2024-05-07T10:46:14.483Z",
    "log.level": "error",  <--------------------- FIXED
    "message": "no input defined",
    "ecs": {
        "version": "1.6.0"
    },
    "input_id": "arn:aws:logs:%AWS_REGION%:627286350134:log-group:constanca-test-esf-log-group:*",
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 151,
                "name": "handler.py"
            },
            "function": "lambda_handler"
        },
        "original": "no input defined"
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 140459008206656,
            "name": "MainThread"
        }
    }
}

{
    "@timestamp": "2024-05-07T10:46:14.698Z",
    "log.level": "info",
    "message": "lambda is going to shutdown",
    "ecs": {
        "version": "1.6.0"
    },
    "empty_events": 0,
    "error_events": 1, <---------------------- NEW
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 161,
                "name": "handler.py"
            },
            "function": "lambda_handler"
        },
        "original": "lambda is going to shutdown"
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 140459008206656,
            "name": "MainThread"
        }
    },
    "sent_events": 0,
    "skipped_events": 0
}

END RequestId: e5adae49-87f2-4b3d-a504-a67cc7aaa421
REPORT RequestId: e5adae49-87f2-4b3d-a504-a67cc7aaa421	Duration: 2370.59 ms	Billed Duration: 2371 ms	Memory Size: 128 MB	Max Memory Used: 107 MB	Init Duration: 697.21 ms
```
</details>

> Note: The input id in the error message is`"input_id": "arn:aws:logs:%AWS_REGION%:627286350134:log-group:constanca-test-esf-log-group:*"`. We don't have access to the region name from the message, so I set it as `%AWS_REGION%`.

### Kinesis data stream trigger

`config.yaml`:
```yaml
"inputs":
- "id": "arn:aws:kinesis:eu-west-2:627286350134:stream/wrong-kinesis"
  "outputs":
  - "args":
      "api_key": "..."
      "elasticsearch_url": "..."
      "es_datastream_name": "logs-esf.kinesis-default"
    "type": "elasticsearch"
  "type": "kinesis-data-stream"
```

And configured `aws_lambda_event_source_mapping` with the correct Kinesis data stream ARN.

<details>
<summary>ESF logs. To make it easier, I annotated the logs with <code><-</code> in the relevant lines.</summary>

```log
INIT_START Runtime Version: python:3.9.v51	Runtime Version ARN: arn:aws:lambda:eu-west-2::runtime:415294d499803f2ba2e75d2753b4523c4517c1c13e55d8ca19a44434f6cbb9a5
{
    "@timestamp": "2024-05-07T12:01:56.950Z",
    "log.level": "info",
    "message": "Found credentials in environment variables.",
    "ecs": {
        "version": "1.6.0"
    },
    "log": {
        "logger": "botocore.credentials",
        "origin": {
            "file": {
                "line": 1147,
                "name": "credentials.py"
            },
            "function": "load"
        },
        "original": "Found credentials in environment variables."
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 139842871994176,
            "name": "MainThread"
        }
    }
}

START RequestId: a2de79e1-fe33-4b17-ac29-ae708b4bf9e0 Version: $LATEST
{
    "@timestamp": "2024-05-07T12:01:57.117Z",
    "log.level": "info",
    "message": "trigger",
    "ecs": {
        "version": "1.6.0"
    },
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 56,
                "name": "handler.py"
            },
            "function": "lambda_handler"
        },
        "original": "trigger"
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 139842871994176,
            "name": "MainThread"
        }
    },
    "type": "kinesis-data-stream"
}

{
    "@timestamp": "2024-05-07T12:01:57.118Z",
    "log.level": "info",
    "message": "config file",
    "bucket_name": "constanca-test-esf-config-bucket",
    "ecs": {
        "version": "1.6.0"
    },
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 204,
                "name": "utils.py"
            },
            "function": "config_yaml_from_s3"
        },
        "original": "config file"
    },
    "object_key": "config.yaml",
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 139842871994176,
            "name": "MainThread"
        }
    }
}

{
    "@timestamp": "2024-05-07T12:01:57.591Z",
    "log.level": "info",
    "message": "trigger",
    "ecs": {
        "version": "1.6.0"
    },
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 237,
                "name": "handler.py"
            },
            "function": "lambda_handler"
        },
        "original": "trigger"
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 139842871994176,
            "name": "MainThread"
        }
    },
    "size": 1
}

{
    "@timestamp": "2024-05-07T12:01:57.592Z",
    "log.level": "error", <----------------------- FIXED
    "message": "no input defined",
    "ecs": {
        "version": "1.6.0"
    },
    "input_id": "arn:aws:kinesis:eu-west-2:627286350134:stream/constanca-test-esf-kinesis",
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 243,
                "name": "handler.py"
            },
            "function": "lambda_handler"
        },
        "original": "no input defined"
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 139842871994176,
            "name": "MainThread"
        }
    }
}

{
    "@timestamp": "2024-05-07T12:01:57.825Z",
    "log.level": "info",
    "message": "lambda is going to shutdown",
    "ecs": {
        "version": "1.6.0"
    },
    "empty_events": 0,
    "error_events": 1, <----------------------- NEW
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 256,
                "name": "handler.py"
            },
            "function": "lambda_handler"
        },
        "original": "lambda is going to shutdown"
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 139842871994176,
            "name": "MainThread"
        }
    },
    "sent_events": 0,
    "skipped_events": 0
}

END RequestId: a2de79e1-fe33-4b17-ac29-ae708b4bf9e0
REPORT RequestId: a2de79e1-fe33-4b17-ac29-ae708b4bf9e0	Duration: 734.63 ms	Billed Duration: 735 ms	Memory Size: 128 MB	Max Memory Used: 89 MB	Init Duration: 716.69 ms
```

</details>


### Replay Queue

After all the three failed triggers, the replay queue has `Messages available: 3`.
