### PR TITLE
Fix workflow typo that is stopping the release of new version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           do
             if [[ ${new_numbers[i]} > ${old_numbers[i]} ]]
             then
-              CREATE_TAG==true
+              CREATE_TAG=true
               break
             elif [[ ${new_numbers[i]} < ${old_numbers[i]} ]]
             then


### PR DESCRIPTION
## What does this PR do?

Fix workflow typo that is stopping the release of new version.


## Details

The workflow got triggered after the merge of PR #711.

However there is a typo that sets the `CREATE_TAG` variable to `=true` instead of `true`, which causes the step `Create tag` to not run:

```
      - name: Create tag
        if: env.CREATE_TAG == 'true' # run only in case CREATE_TAG is true
```

You can see that in this run: https://github.com/elastic/elastic-serverless-forwarder/actions/runs/9079114205/job/24947621376.

## How to test this PR locally

It is not possible to test this locally.

Best workaround would be to create your own private repository and create the same environment to make the workflow get triggered.