### PR TITLE
Enable multiple outputs for each input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### v1.15.0 - 2024/05/29
 ##### Features
-* Enable multiple outputs for each input []()
+* Enable multiple outputs for each input [725](https://github.com/elastic/elastic-serverless-forwarder/pull/725).
 
 ### v1.14.0 - 2024/05/07
 ##### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.15.0 - 2024/05/29
+##### Features
+* Enable multiple outputs for each input []()
+
 ### v1.14.0 - 2024/05/07
 ##### Bug fixes
 * Report misconfigured input ids as an error instead of warning, and place those messages in the replaying queue [#711](https://github.com/elastic/elastic-serverless-forwarder/pull/711).

--- a/handlers/aws/handler.py
+++ b/handlers/aws/handler.py
@@ -101,7 +101,10 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
                 if shipper is None:
                     shared_logger.warning(
                         "no shipper for output in replay queue",
-                        extra={"output_destination": event["output_destination"], "event_input_id": event["event_input_id"]},
+                        extra={
+                            "output_destination": event["output_destination"],
+                            "event_input_id": event["event_input_id"],
+                        },
                     )
                     continue
 

--- a/handlers/aws/replay_trigger.py
+++ b/handlers/aws/replay_trigger.py
@@ -20,7 +20,9 @@ class ReplayedEventReplayHandler:
     def add_event_with_receipt_handle(self, event_uniq_id: str, receipt_handle: str) -> None:
         self._events_with_receipt_handle[event_uniq_id] = receipt_handle
 
-    def replay_handler(self, output_destination: str, output_args: dict[str, Any], event_payload: dict[str, Any]) -> None:
+    def replay_handler(
+        self, output_destination: str, output_args: dict[str, Any], event_payload: dict[str, Any]
+    ) -> None:
         event_uniq_id: str = event_payload["_id"] + output_destination
         self._failed_event_ids.append(event_uniq_id)
 

--- a/handlers/aws/replay_trigger.py
+++ b/handlers/aws/replay_trigger.py
@@ -20,8 +20,8 @@ class ReplayedEventReplayHandler:
     def add_event_with_receipt_handle(self, event_uniq_id: str, receipt_handle: str) -> None:
         self._events_with_receipt_handle[event_uniq_id] = receipt_handle
 
-    def replay_handler(self, output_type: str, output_args: dict[str, Any], event_payload: dict[str, Any]) -> None:
-        event_uniq_id: str = event_payload["_id"] + output_type
+    def replay_handler(self, output_destination: str, output_args: dict[str, Any], event_payload: dict[str, Any]) -> None:
+        event_uniq_id: str = event_payload["_id"] + output_destination
         self._failed_event_ids.append(event_uniq_id)
 
     def flush(self) -> None:

--- a/handlers/aws/replay_trigger.py
+++ b/handlers/aws/replay_trigger.py
@@ -37,7 +37,7 @@ class ReplayedEventReplayHandler:
 
 def get_shipper_for_replay_event(
     config: Config,
-    output_type: str,
+    output_destination: str,
     output_args: dict[str, Any],
     event_input_id: str,
     replay_handler: ReplayedEventReplayHandler,
@@ -46,28 +46,28 @@ def get_shipper_for_replay_event(
     if event_input is None:
         raise InputConfigException(f"Cannot load input for input id {event_input_id}")
 
-    output: Optional[Output] = event_input.get_output_by_type(output_type)
+    output: Optional[Output] = event_input.get_output_by_destination(output_destination)
     if output is None:
-        raise OutputConfigException(f"Cannot load output of type {output_type}")
+        raise OutputConfigException(f"Cannot load output with destination {output_destination}")
 
     # Let's wrap the specific output shipper in the composite one, since the composite deepcopy the mutating events
     shipper: CompositeShipper = CompositeShipper()
 
-    if output_type == "elasticsearch":
+    if output.type == "elasticsearch":
         assert isinstance(output, ElasticsearchOutput)
         output.es_datastream_name = output_args["es_datastream_name"]
         shared_logger.debug("setting ElasticSearch shipper")
-        elasticsearch: ProtocolShipper = ShipperFactory.create_from_output(output_type=output_type, output=output)
+        elasticsearch: ProtocolShipper = ShipperFactory.create_from_output(output_type=output.type, output=output)
 
         shipper.add_shipper(elasticsearch)
         shipper.set_replay_handler(replay_handler=replay_handler.replay_handler)
 
         return shipper
 
-    if output_type == "logstash":
+    if output.type == "logstash":
         assert isinstance(output, LogstashOutput)
         shared_logger.debug("setting Logstash shipper")
-        logstash: ProtocolShipper = ShipperFactory.create_from_output(output_type=output_type, output=output)
+        logstash: ProtocolShipper = ShipperFactory.create_from_output(output_type=output.type, output=output)
 
         shipper.add_shipper(logstash)
         shipper.set_replay_handler(replay_handler=replay_handler.replay_handler)

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -153,9 +153,7 @@ def get_shipper_from_input(event_input: Input) -> CompositeShipper:
         if output.type == "logstash":
             shared_logger.debug("setting Logstash shipper")
 
-            logstash_shipper: ProtocolShipper = ShipperFactory.create_from_output(
-                output_type="logstash", output=output
-            )
+            logstash_shipper: ProtocolShipper = ShipperFactory.create_from_output(output_type="logstash", output=output)
 
             composite_shipper.add_shipper(shipper=logstash_shipper)
 
@@ -348,7 +346,9 @@ class ReplayEventHandler:
     def __init__(self, event_input: Input):
         self._event_input_id: str = event_input.id
 
-    def replay_handler(self, output_destination: str, output_args: dict[str, Any], event_payload: dict[str, Any]) -> None:
+    def replay_handler(
+        self, output_destination: str, output_args: dict[str, Any], event_payload: dict[str, Any]
+    ) -> None:
         sqs_replay_queue = os.environ["SQS_REPLAY_URL"]
 
         sqs_client = get_sqs_client()
@@ -363,7 +363,8 @@ class ReplayEventHandler:
         sqs_client.send_message(QueueUrl=sqs_replay_queue, MessageBody=json_dumper(message_payload))
 
         shared_logger.debug(
-            "sent to replay queue", extra={"output_destination": output_destination, "event_input_id": self._event_input_id}
+            "sent to replay queue",
+            extra={"output_destination": output_destination, "event_input_id": self._event_input_id},
         )
 
 

--- a/share/config.py
+++ b/share/config.py
@@ -443,6 +443,7 @@ class Input:
             # for the same url/cloud_id for both types logstash or elasticsearch
             raise ValueError(f"Duplicated output destination {output_dest} for type {output_type}")
 
+        output: Optional[Output] = None
         if output_type == "elasticsearch":
             output = ElasticsearchOutput(**kwargs)
         elif output_type == "logstash":

--- a/share/config.py
+++ b/share/config.py
@@ -407,7 +407,6 @@ class Input:
 
         return list(self._outputs.keys())
 
-    # TODO
     def delete_output_by_destination(self, output_destination: str) -> None:
         """
         Output deleter.
@@ -431,7 +430,6 @@ class Input:
                 raise ValueError("Either `elasticsearch_url` or `cloud_id` must be set")
             # elasticsearch_url takes precedence over cloud_id
             if "elasticsearch_url" not in kwargs:
-
                 output_dest = kwargs["cloud_id"]
             else:
                 output_dest = kwargs["elasticsearch_url"]
@@ -440,8 +438,6 @@ class Input:
                 raise ValueError(f"Output type {output_type} requires logstash_url to be set")
             output_dest = kwargs["logstash_url"]
 
-        print("Outpus is ", self._outputs)
-        print(f"Output dest is {output_dest}")
         if output_dest in self._outputs:
             # Since logstash destination can only be set as logstash_url, we do not have to account
             # for the same url/cloud_id for both types logstash or elasticsearch

--- a/share/config.py
+++ b/share/config.py
@@ -63,9 +63,6 @@ class ElasticsearchOutput(Output):
         self.batch_max_bytes = batch_max_bytes
         self.ssl_assert_fingerprint = ssl_assert_fingerprint
 
-        if not self.cloud_id and not self.elasticsearch_url:
-            raise ValueError("One between `elasticsearch_url` or `cloud_id` must be set")
-
         if self.cloud_id and self.elasticsearch_url:
             shared_logger.warning("both `elasticsearch_url` and `cloud_id` set in config: using `elasticsearch_url`")
             self.cloud_id = ""
@@ -394,42 +391,62 @@ class Input:
 
         self._include_exclude_filter = value
 
-    def get_output_by_type(self, output_type: str) -> Optional[Output]:
+    def get_output_by_destination(self, output_destination: str) -> Optional[Output]:
         """
         Output getter.
-        Returns a specific output given its type
+        Returns a specific output given its destination
         """
 
-        return self._outputs[output_type] if output_type in self._outputs else None
+        return self._outputs[output_destination] if output_destination in self._outputs else None
 
-    def get_output_types(self) -> list[str]:
+    def get_output_destinations(self) -> list[str]:
         """
-        Output types getter.
-        Returns all the defined output types
+        Output destinations getter.
+        Returns all the defined output destinations
         """
 
         return list(self._outputs.keys())
 
-    def delete_output_by_type(self, output_type: str) -> None:
+    # TODO
+    def delete_output_by_destination(self, output_destination: str) -> None:
         """
         Output deleter.
         Delete a defined output by its type
         """
 
-        del self._outputs[output_type]
+        del self._outputs[output_destination]
 
     def add_output(self, output_type: str, **kwargs: Any) -> None:
         """
         Output setter.
         Set an output given its type and init kwargs
         """
-        if not isinstance(output_type, str):
-            raise ValueError("`type` must be provided as string")
 
-        if output_type in self._outputs:
-            raise ValueError(f"Duplicated `type` {output_type}")
+        if output_type not in _available_output_types:
+            raise ValueError(f"Type {output_type} is not included in the supported types: {_available_output_types}")
 
-        output: Optional[Output] = None
+        output_dest = ""
+        if output_type == "elasticsearch":
+            if "cloud_id" not in kwargs and "elasticsearch_url" not in kwargs:
+                raise ValueError("Either `elasticsearch_url` or `cloud_id` must be set")
+            # elasticsearch_url takes precedence over cloud_id
+            if "elasticsearch_url" not in kwargs:
+
+                output_dest = kwargs["cloud_id"]
+            else:
+                output_dest = kwargs["elasticsearch_url"]
+        elif output_type == "logstash":
+            if "logstash_url" not in kwargs:
+                raise ValueError(f"Output type {output_type} requires logstash_url to be set")
+            output_dest = kwargs["logstash_url"]
+
+        print("Outpus is ", self._outputs)
+        print(f"Output dest is {output_dest}")
+        if output_dest in self._outputs:
+            # Since logstash destination can only be set as logstash_url, we do not have to account
+            # for the same url/cloud_id for both types logstash or elasticsearch
+            raise ValueError(f"Duplicated output destination {output_dest} for type {output_type}")
+
         if output_type == "elasticsearch":
             output = ElasticsearchOutput(**kwargs)
         elif output_type == "logstash":
@@ -437,7 +454,7 @@ class Input:
         else:
             output = Output(output_type=output_type)
 
-        self._outputs[output.type] = output
+        self._outputs[output_dest] = output
 
     def get_multiline_processor(self) -> Optional[ProtocolMultiline]:
         return self._multiline_processor

--- a/share/version.py
+++ b/share/version.py
@@ -2,4 +2,4 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-version = "1.14.0"
+version = "1.15.0"

--- a/shippers/es.py
+++ b/shippers/es.py
@@ -80,8 +80,10 @@ class ElasticsearchShipper:
         es_client_kwargs: dict[str, Any] = {}
         if elasticsearch_url:
             es_client_kwargs["hosts"] = [elasticsearch_url]
+            self._output_destination = elasticsearch_url
         elif cloud_id:
             es_client_kwargs["cloud_id"] = cloud_id
+            self._output_destination = cloud_id
         else:
             raise ValueError("You must provide one between elasticsearch_url or cloud_id")
 
@@ -166,7 +168,7 @@ class ElasticsearchShipper:
             )
             shared_logger.debug("elasticsearch shipper", extra={"action": action_failed[0]})
             if self._replay_handler is not None:
-                self._replay_handler("elasticsearch", self._replay_args, action_failed[0])
+                self._replay_handler(self._output_destination, self._replay_args, action_failed[0])
 
         if failed > 0:
             shared_logger.warning("elasticsearch shipper", extra={"success": success, "failed": failed})

--- a/shippers/logstash.py
+++ b/shippers/logstash.py
@@ -155,4 +155,4 @@ class LogstashShipper:
                         event["_id"] = event["@metadata"]["_id"]
                         del event["@metadata"]
 
-                    self._replay_handler("logstash", self._replay_args, event)
+                    self._replay_handler(self._logstash_url, self._replay_args, event)

--- a/tests/handlers/aws/test_handler.py
+++ b/tests/handlers/aws/test_handler.py
@@ -546,7 +546,9 @@ class TestLambdaHandlerFailure(TestCase):
                     }
                 ]
             }
-            with self.assertRaisesRegex(OutputConfigException, "Cannot load output with destination output_destination"):
+            with self.assertRaisesRegex(
+                OutputConfigException, "Cannot load output with destination output_destination"
+            ):
                 ctx = ContextMock()
 
                 handler(event, ctx)  # type:ignore

--- a/tests/handlers/aws/test_handler.py
+++ b/tests/handlers/aws/test_handler.py
@@ -420,7 +420,7 @@ class TestLambdaHandlerNoop(TestCase):
         with self.subTest("output not elasticsearch from payload config"):
             with mock.patch(
                 "handlers.aws.handler.get_shipper_for_replay_event",
-                lambda config, output_type, output_args, event_input_id, replay_handler: None,
+                lambda config, output_destination, output_args, event_input_id, replay_handler: None,
             ):
                 ctx = ContextMock()
                 event = {
@@ -428,7 +428,7 @@ class TestLambdaHandlerNoop(TestCase):
                         {
                             "eventSourceARN": "arn:aws:sqs:eu-central-1:123456789:replay-queue",
                             "receiptHandle": "receiptHandle",
-                            "body": '{"output_type": "output_type", "output_args": {},'
+                            "body": '{"output_destination": "output_destination", "output_args": {},'
                             '"event_input_id": "arn:aws:sqs:eu-central-1:123456789:s3-sqs-queue", '
                             '"event_payload": {"_id": "_id"}}',
                         }
@@ -540,13 +540,13 @@ class TestLambdaHandlerFailure(TestCase):
                     {
                         "eventSourceARN": "arn:aws:sqs:eu-central-1:123456789:replay-queue",
                         "receiptHandle": "receiptHandle",
-                        "body": '{"output_type": "output_type", "output_args": {},'
+                        "body": '{"output_destination": "output_destination", "output_args": {},'
                         '"event_input_id": "arn:aws:dummy:eu-central-1:123456789:input", '
                         '"event_payload": {"_id": "_id"}}',
                     }
                 ]
             }
-            with self.assertRaisesRegex(OutputConfigException, "Cannot load output of type output_type"):
+            with self.assertRaisesRegex(OutputConfigException, "Cannot load output with destination output_destination"):
                 ctx = ContextMock()
 
                 handler(event, ctx)  # type:ignore
@@ -558,7 +558,7 @@ class TestLambdaHandlerFailure(TestCase):
                     {
                         "eventSourceARN": "arn:aws:sqs:eu-central-1:123456789:replay-queue",
                         "receiptHandle": "receiptHandle",
-                        "body": '{"output_type": "output_type", "output_args": {},'
+                        "body": '{"output_destination": "output_destination", "output_args": {},'
                         '"event_input_id": "arn:aws:dummy:eu-central-1:123456789:not-existing-input", '
                         '"event_payload": {"_id": "_id"}}',
                     }
@@ -657,7 +657,7 @@ class TestLambdaHandlerFailure(TestCase):
                 event = {
                     "Records": [
                         {
-                            "body": '{"output_type": "", "output_args": "", "event_payload": ""}',
+                            "body": '{"output_destination": "", "output_args": "", "event_payload": ""}',
                         }
                     ]
                 }

--- a/tests/handlers/aws/test_utils.py
+++ b/tests/handlers/aws/test_utils.py
@@ -92,7 +92,7 @@ class TestGetTriggerTypeAndConfigSource(TestCase):
             event = {
                 "Records": [
                     {
-                        "body": '{"output_type": "output_type", '
+                        "body": '{"output_destination": "output_destination", '
                                 '"output_args": "output_args", "event_payload": "event_payload"}'
                     }
                 ]

--- a/tests/handlers/aws/test_utils.py
+++ b/tests/handlers/aws/test_utils.py
@@ -93,7 +93,7 @@ class TestGetTriggerTypeAndConfigSource(TestCase):
                 "Records": [
                     {
                         "body": '{"output_destination": "output_destination", '
-                                '"output_args": "output_args", "event_payload": "event_payload"}'
+                        '"output_args": "output_args", "event_payload": "event_payload"}'
                     }
                 ]
             }
@@ -261,8 +261,9 @@ class TestGetShipperFromInput(TestCase):
             assert len(shipper._shippers) == 1
             assert isinstance(shipper._shippers[0], LogstashShipper)
 
-            event_input_kinesis = config.get_input_by_id("arn:aws:kinesis:eu-central-1:123456789:stream/test-esf"
-                                                         "-kinesis-stream")
+            event_input_kinesis = config.get_input_by_id(
+                "arn:aws:kinesis:eu-central-1:123456789:stream/test-esf" "-kinesis-stream"
+            )
             assert event_input_kinesis is not None
             shipper = get_shipper_from_input(event_input=event_input_kinesis)
             assert len(shipper._shippers) == 1

--- a/tests/handlers/aws/test_utils.py
+++ b/tests/handlers/aws/test_utils.py
@@ -239,7 +239,7 @@ class TestGetShipperFromInput(TestCase):
             assert isinstance(shipper._shippers[0], LogstashShipper)
 
         with self.subTest("Logstash shipper from each input"):
-            config_yaml_cw: str = """
+            config_yaml_cw = """
                                 inputs:
                                   - type: cloudwatch-logs
                                     id: arn:aws:logs:eu-central-1:123456789:stream/test-cw-logs
@@ -273,7 +273,7 @@ class TestGetShipperFromInput(TestCase):
             event_input_kinesis.delete_output_by_destination("logstash_url")
 
         with self.subTest("Two Logstash shippers from Cloudwatch logs input"):
-            config_yaml_cw: str = """
+            config_yaml_cw = """
                                 inputs:
                                   - type: cloudwatch-logs
                                     id: arn:aws:logs:eu-central-1:123456789:stream/test-cw-logs
@@ -296,7 +296,7 @@ class TestGetShipperFromInput(TestCase):
             event_input.delete_output_by_destination("logstash_url-2")
 
         with self.subTest("Two outputs with the same logstash_url"):
-            config_yaml_cw: str = """
+            config_yaml_cw = """
                                 inputs:
                                   - type: cloudwatch-logs
                                     id: arn:aws:logs:eu-central-1:123456789:stream/test-cw-logs

--- a/tests/handlers/aws/test_utils.py
+++ b/tests/handlers/aws/test_utils.py
@@ -93,7 +93,7 @@ class TestGetTriggerTypeAndConfigSource(TestCase):
                 "Records": [
                     {
                         "body": '{"output_type": "output_type", '
-                        '"output_args": "output_args", "event_payload": "event_payload"}'
+                                '"output_args": "output_args", "event_payload": "event_payload"}'
                     }
                 ]
             }
@@ -216,9 +216,10 @@ class TestGetShipperFromInput(TestCase):
                 "arn:aws:kinesis:eu-central-1:123456789:stream/test-esf-kinesis-stream"
             )
             assert event_input is not None
-            shipper = get_shipper_from_input(event_input=event_input, config_yaml=config_yaml_kinesis)
+            shipper = get_shipper_from_input(event_input=event_input)
             assert len(shipper._shippers) == 1
             assert isinstance(shipper._shippers[0], LogstashShipper)
+            event_input.delete_output_by_destination("logstash_url")
 
         with self.subTest("Logstash shipper from Cloudwatch logs input"):
             config_yaml_cw: str = """
@@ -233,9 +234,81 @@ class TestGetShipperFromInput(TestCase):
             config = parse_config(config_yaml_cw)
             event_input = config.get_input_by_id("arn:aws:logs:eu-central-1:123456789:stream/test-cw-logs")
             assert event_input is not None
-            shipper = get_shipper_from_input(event_input=event_input, config_yaml=config_yaml_cw)
+            shipper = get_shipper_from_input(event_input=event_input)
             assert len(shipper._shippers) == 1
             assert isinstance(shipper._shippers[0], LogstashShipper)
+
+        with self.subTest("Logstash shipper from each input"):
+            config_yaml_cw: str = """
+                                inputs:
+                                  - type: cloudwatch-logs
+                                    id: arn:aws:logs:eu-central-1:123456789:stream/test-cw-logs
+                                    outputs:
+                                        - type: logstash
+                                          args:
+                                            logstash_url: logstash_url
+                                  - type: kinesis-data-stream
+                                    id: arn:aws:kinesis:eu-central-1:123456789:stream/test-esf-kinesis-stream
+                                    outputs:
+                                        - type: logstash
+                                          args:
+                                            logstash_url: logstash_url
+                            """
+            config = parse_config(config_yaml_cw)
+            event_input_cw = config.get_input_by_id("arn:aws:logs:eu-central-1:123456789:stream/test-cw-logs")
+            assert event_input_cw is not None
+            shipper = get_shipper_from_input(event_input=event_input_cw)
+            assert len(shipper._shippers) == 1
+            assert isinstance(shipper._shippers[0], LogstashShipper)
+
+            event_input_kinesis = config.get_input_by_id("arn:aws:kinesis:eu-central-1:123456789:stream/test-esf"
+                                                         "-kinesis-stream")
+            assert event_input_kinesis is not None
+            shipper = get_shipper_from_input(event_input=event_input_kinesis)
+            assert len(shipper._shippers) == 1
+            assert isinstance(shipper._shippers[0], LogstashShipper)
+
+            event_input_cw.delete_output_by_destination("logstash_url")
+            event_input_kinesis.delete_output_by_destination("logstash_url")
+
+        with self.subTest("Two Logstash shippers from Cloudwatch logs input"):
+            config_yaml_cw: str = """
+                                inputs:
+                                  - type: cloudwatch-logs
+                                    id: arn:aws:logs:eu-central-1:123456789:stream/test-cw-logs
+                                    outputs:
+                                        - type: logstash
+                                          args:
+                                            logstash_url: logstash_url-1
+                                        - type: logstash
+                                          args:
+                                            logstash_url: logstash_url-2
+                            """
+            config = parse_config(config_yaml_cw)
+            event_input = config.get_input_by_id("arn:aws:logs:eu-central-1:123456789:stream/test-cw-logs")
+            assert event_input is not None
+            shipper = get_shipper_from_input(event_input=event_input)
+            assert len(shipper._shippers) == 2
+            assert isinstance(shipper._shippers[0], LogstashShipper)
+            assert isinstance(shipper._shippers[1], LogstashShipper)
+            event_input.delete_output_by_destination("logstash_url-1")
+            event_input.delete_output_by_destination("logstash_url-2")
+
+        with self.subTest("Two outputs with the same logstash_url"):
+            config_yaml_cw: str = """
+                                inputs:
+                                  - type: cloudwatch-logs
+                                    id: arn:aws:logs:eu-central-1:123456789:stream/test-cw-logs
+                                    outputs:
+                                        - type: logstash
+                                          args:
+                                            logstash_url: logstash_url
+                                        - type: logstash
+                                          args:
+                                            logstash_url: logstash_url
+                            """
+            with self.assertRaisesRegex(ValueError, "logstash_url"):
+                parse_config(config_yaml_cw)
 
 
 @pytest.mark.unit

--- a/tests/share/test_config.py
+++ b/tests/share/test_config.py
@@ -591,8 +591,9 @@ class TestInput(TestCase):
                 batch_max_bytes=1,
             )
 
-            assert isinstance(input_sqs.get_output_by_destination(output_destination="elasticsearch_url"),
-                              ElasticsearchOutput)
+            assert isinstance(
+                input_sqs.get_output_by_destination(output_destination="elasticsearch_url"), ElasticsearchOutput
+            )
 
         with self.subTest("logstash output"):
             input_sqs = Input(input_type="s3-sqs", input_id="id")
@@ -616,8 +617,9 @@ class TestInput(TestCase):
                 batch_max_bytes=1,
             )
 
-            assert isinstance(input_sqs.get_output_by_destination(output_destination="elasticsearch_url"),
-                              ElasticsearchOutput)
+            assert isinstance(
+                input_sqs.get_output_by_destination(output_destination="elasticsearch_url"), ElasticsearchOutput
+            )
 
         with self.subTest("logstash output"):
             input_sqs = Input(input_type="s3-sqs", input_id="id")

--- a/tests/share/test_config.py
+++ b/tests/share/test_config.py
@@ -134,10 +134,6 @@ class TestElasticsearchOutput(TestCase):
             assert elasticsearch.batch_max_bytes == 1
             assert elasticsearch.ssl_assert_fingerprint == ""
 
-        with self.subTest("neither elasticsearch_url or cloud_id"):
-            with self.assertRaisesRegex(ValueError, "`elasticsearch_url` or `cloud_id` must be set"):
-                ElasticsearchOutput(elasticsearch_url="", cloud_id="")
-
         with self.subTest("both elasticsearch_url and cloud_id"):
             elasticsearch = ElasticsearchOutput(
                 elasticsearch_url="elasticsearch_url",
@@ -581,7 +577,7 @@ class TestInput(TestCase):
     def test_get_output_by_type(self) -> None:
         with self.subTest("none output"):
             input_sqs = Input(input_type="s3-sqs", input_id="id")
-            assert input_sqs.get_output_by_type(output_type="test") is None
+            assert input_sqs.get_output_by_destination(output_destination="test") is None
 
         with self.subTest("elasticsearch output"):
             input_sqs = Input(input_type="s3-sqs", input_id="id")
@@ -595,7 +591,8 @@ class TestInput(TestCase):
                 batch_max_bytes=1,
             )
 
-            assert isinstance(input_sqs.get_output_by_type(output_type="elasticsearch"), ElasticsearchOutput)
+            assert isinstance(input_sqs.get_output_by_destination(output_destination="elasticsearch_url"),
+                              ElasticsearchOutput)
 
         with self.subTest("logstash output"):
             input_sqs = Input(input_type="s3-sqs", input_id="id")
@@ -604,7 +601,7 @@ class TestInput(TestCase):
                 logstash_url="logstash_url",
             )
 
-            assert isinstance(input_sqs.get_output_by_type(output_type="logstash"), LogstashOutput)
+            assert isinstance(input_sqs.get_output_by_destination(output_destination="logstash_url"), LogstashOutput)
 
     def test_add_output(self) -> None:
         with self.subTest("elasticsearch output"):
@@ -619,7 +616,8 @@ class TestInput(TestCase):
                 batch_max_bytes=1,
             )
 
-            assert isinstance(input_sqs.get_output_by_type(output_type="elasticsearch"), ElasticsearchOutput)
+            assert isinstance(input_sqs.get_output_by_destination(output_destination="elasticsearch_url"),
+                              ElasticsearchOutput)
 
         with self.subTest("logstash output"):
             input_sqs = Input(input_type="s3-sqs", input_id="id")
@@ -631,49 +629,19 @@ class TestInput(TestCase):
                 ssl_assert_fingerprint="fingerprint",
             )
 
-            assert isinstance(input_sqs.get_output_by_type(output_type="logstash"), LogstashOutput)
+            assert isinstance(input_sqs.get_output_by_destination(output_destination="logstash_url"), LogstashOutput)
 
         with self.subTest("not elasticsearch or logstash output"):
             input_sqs = Input(input_type="s3-sqs", input_id="id")
-            with self.assertRaisesRegex(
-                ValueError, "^`type` must be one of elasticsearch,logstash: another-type given$"
-            ):
+            with self.assertRaisesRegex(ValueError, "another-type"):
                 input_sqs.add_output(output_type="another-type")
 
-        with self.subTest("type is not str"):
-            input_sqs = Input(input_type="s3-sqs", input_id="id")
-            with self.assertRaisesRegex(ValueError, "`type` must be provided as string"):
-                input_sqs.add_output(output_type=0)  # type:ignore
-
-        with self.subTest("type is duplicated"):
-            input_sqs = Input(input_type="s3-sqs", input_id="id")
-            input_sqs.add_output(
-                output_type="elasticsearch",
-                elasticsearch_url="elasticsearch_url",
-                username="username",
-                password="password",
-                es_datastream_name="es_datastream_name",
-                batch_max_actions=1,
-                batch_max_bytes=1,
-            )
-
-            with self.assertRaisesRegex(ValueError, "Duplicated `type` elasticsearch"):
-                input_sqs.add_output(
-                    output_type="elasticsearch",
-                    elasticsearch_url="elasticsearch_url",
-                    username="username",
-                    password="password",
-                    es_datastream_name="es_datastream_name",
-                    batch_max_actions=1,
-                    batch_max_bytes=1,
-                )
-
-    def test_get_output_types(self) -> None:
+    def test_get_output_destinations(self) -> None:
         with self.subTest("none output"):
             input_sqs = Input(input_type="s3-sqs", input_id="id")
-            assert input_sqs.get_output_types() == []
+            assert input_sqs.get_output_destinations() == []
 
-        with self.subTest("elasticsearch output"):
+        with self.subTest("elasticsearch output with only elasticsearch_url set"):
             input_sqs = Input(input_type="s3-sqs", input_id="id")
             input_sqs.add_output(
                 output_type="elasticsearch",
@@ -685,7 +653,36 @@ class TestInput(TestCase):
                 batch_max_bytes=1,
             )
 
-            assert input_sqs.get_output_types() == ["elasticsearch"]
+            assert input_sqs.get_output_destinations() == ["elasticsearch_url"]
+
+        with self.subTest("elasticsearch output with only cloud_id set"):
+            input_sqs = Input(input_type="s3-sqs", input_id="id")
+            input_sqs.add_output(
+                output_type="elasticsearch",
+                cloud_id="cloud_id",
+                username="username",
+                password="password",
+                es_datastream_name="es_datastream_name",
+                batch_max_actions=1,
+                batch_max_bytes=1,
+            )
+
+            assert input_sqs.get_output_destinations() == ["cloud_id"]
+
+        with self.subTest("elasticsearch output with elasticsearch_url and cloud_id set"):
+            input_sqs = Input(input_type="s3-sqs", input_id="id")
+            input_sqs.add_output(
+                output_type="elasticsearch",
+                elasticsearch_url="elasticsearch_url",
+                cloud_id="cloud_id",
+                username="username",
+                password="password",
+                es_datastream_name="es_datastream_name",
+                batch_max_actions=1,
+                batch_max_bytes=1,
+            )
+
+            assert input_sqs.get_output_destinations() == ["elasticsearch_url"]
 
     def test_delete_output_by_type(self) -> None:
         with self.subTest("delete elasticsearch output"):
@@ -700,13 +697,13 @@ class TestInput(TestCase):
                 batch_max_bytes=1,
             )
 
-            input_sqs.delete_output_by_type("elasticsearch")
-            assert input_sqs.get_output_types() == []
+            input_sqs.delete_output_by_destination("elasticsearch_url")
+            assert input_sqs.get_output_destinations() == []
 
         with self.subTest("delete not existing output"):
             input_sqs = Input(input_type="s3-sqs", input_id="id")
-            with self.assertRaisesRegex(KeyError, "'type"):
-                input_sqs.delete_output_by_type("type")
+            with self.assertRaisesRegex(KeyError, "destination"):
+                input_sqs.delete_output_by_destination("destination")
 
 
 @pytest.mark.unit
@@ -899,36 +896,6 @@ class TestParseConfig(TestCase):
             """
                 )
 
-        with self.subTest("not valid input output"):
-            with self.assertRaisesRegex(
-                ValueError,
-                "^An error occurred while applying output configuration at position 1 for input id: "
-                "`type` must be one of elasticsearch,logstash: another-type given$",
-            ):
-                parse_config(
-                    config_yaml="""
-            inputs:
-              - type: s3-sqs
-                id: id
-                outputs:
-                  - type: another-type
-                    args:
-                      key: value
-            """
-                )
-
-            with self.assertRaisesRegex(ValueError, "One between `elasticsearch_url` or `cloud_id` must be set"):
-                parse_config(
-                    config_yaml="""
-            inputs:
-              - type: s3-sqs
-                id: id
-                outputs:
-                  - type: elasticsearch
-                    args: {}
-            """
-                )
-
         with self.subTest("batch_max_actions not int"):
             with self.assertRaisesRegex(
                 ValueError,
@@ -1070,7 +1037,7 @@ class TestParseConfig(TestCase):
             assert input_sqs.type == "s3-sqs"
             assert input_sqs.id == "id"
             assert input_sqs.expand_event_list_from_field == "aField"
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="cloud_id")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)
@@ -1123,7 +1090,7 @@ class TestParseConfig(TestCase):
             assert input_sqs.type == "s3-sqs"
             assert input_sqs.id == "id"
             assert input_sqs.root_fields_to_add_to_expanded_event == "all"
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="cloud_id")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)
@@ -1157,7 +1124,7 @@ class TestParseConfig(TestCase):
             assert input_sqs.type == "s3-sqs"
             assert input_sqs.id == "id"
             assert input_sqs.root_fields_to_add_to_expanded_event == ["one", "two"]
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="cloud_id")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)
@@ -1399,7 +1366,7 @@ class TestParseConfig(TestCase):
             assert input_sqs.id == "id"
             assert input_sqs.tags == ["tag1", "tag2", "tag3"]
 
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="elasticsearch_url")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)
@@ -1438,7 +1405,7 @@ class TestParseConfig(TestCase):
             assert input_sqs.id == "id"
             assert input_sqs.tags == ["tag1", "tag2", "tag3"]
 
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="elasticsearch_url")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)
@@ -1477,7 +1444,7 @@ class TestParseConfig(TestCase):
             assert input_sqs.id == "id"
             assert input_sqs.tags == ["tag1", "tag2", "tag3"]
 
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="cloud_id")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)
@@ -1516,7 +1483,7 @@ class TestParseConfig(TestCase):
             assert input_sqs.id == "id"
             assert input_sqs.tags == ["tag1", "tag2", "tag3"]
 
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="cloud_id")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)
@@ -1554,7 +1521,7 @@ class TestParseConfig(TestCase):
             assert input_sqs.id == "id"
             assert input_sqs.tags == []
 
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="cloud_id")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)
@@ -1595,7 +1562,7 @@ class TestParseConfig(TestCase):
             assert input_sqs.id == "id"
             assert input_sqs.tags == ["input_tag1", "input_tag2"]
 
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="cloud_id")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)
@@ -1633,7 +1600,7 @@ class TestParseConfig(TestCase):
             assert input_sqs.id == "id"
             assert input_sqs.tags == ["tag1", "tag2", "tag3"]
 
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="cloud_id")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)
@@ -1682,7 +1649,7 @@ class TestParseConfig(TestCase):
                 ],
             )
 
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="cloud_id")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)
@@ -1697,7 +1664,7 @@ class TestParseConfig(TestCase):
 
         with self.subTest("no list for include"):
             with self.assertRaisesRegex(ValueError, "`include` must be provided as list for input id"):
-                config = parse_config(
+                parse_config(
                     config_yaml="""
                 inputs:
                   - type: s3-sqs
@@ -1718,7 +1685,7 @@ class TestParseConfig(TestCase):
 
         with self.subTest("no list for exclude"):
             with self.assertRaisesRegex(ValueError, "`exclude` must be provided as list for input id"):
-                config = parse_config(
+                parse_config(
                     config_yaml="""
                 inputs:
                   - type: s3-sqs
@@ -1936,7 +1903,7 @@ class TestParseConfig(TestCase):
             assert input_sqs.id == "id"
             assert input_sqs.tags == []
 
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="cloud_id")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)
@@ -1971,7 +1938,7 @@ class TestParseConfig(TestCase):
             assert input_sqs.id == "id"
             assert input_sqs.tags == []
 
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="cloud_id")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)
@@ -2006,7 +1973,7 @@ class TestParseConfig(TestCase):
             assert input_sqs.id == "id"
             assert input_sqs.tags == []
 
-            elasticsearch = input_sqs.get_output_by_type(output_type="elasticsearch")
+            elasticsearch = input_sqs.get_output_by_destination(output_destination="cloud_id")
 
             assert elasticsearch is not None
             assert isinstance(elasticsearch, ElasticsearchOutput)

--- a/tests/shippers/test_logstash.py
+++ b/tests/shippers/test_logstash.py
@@ -133,7 +133,7 @@ class TestLogstashShipper(TestCase):
             logstash_shipper.set_replay_handler(replay_handler)
             event = deepcopy(_dummy_event)
             assert logstash_shipper.send(event) == _EVENT_SENT
-            replay_handler.assert_called_once_with("logstash", {}, event)
+            replay_handler.assert_called_once_with(url, {}, event)
         with self.subTest("Exceeds max retries, replay handler not set"):
             for i in range(_MAX_RETRIES):
                 responses.put(url=url, status=429)
@@ -150,7 +150,7 @@ class TestLogstashShipper(TestCase):
             logstash_shipper.set_replay_handler(replay_handler)
             event = deepcopy(_dummy_event)
             assert logstash_shipper.send(event) == _EVENT_SENT
-            replay_handler.assert_called_once_with("logstash", {}, event)
+            replay_handler.assert_called_once_with(url, {}, event)
 
     @responses.activate
     def test_flush(self) -> None:


### PR DESCRIPTION
## What does this PR do?

Each input can now have multiple outputs of the same `type`. It cannot, however, have the same output specified more than once for each input - that is, it cannot have two `elasticsearch` outputs with the same destination. See section **Results** for examples.

## Why is it important?

See details on https://github.com/elastic/elastic-serverless-forwarder/issues/721.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md`

## How to test this PR locally

Refer to https://github.com/elastic/elastic-serverless-forwarder/tree/main/how-to-test-locally.

## Related issues

Relates to https://github.com/elastic/elastic-serverless-forwarder/issues/721


## Results


### Example 1: Trying 2 `elasticsearch` outputs

I have an input with two `elasticsearch` outputs:
```yaml
"inputs":
- "id": "arn:aws:logs:eu-west-2:627286350134:log-group:constanca-test-local-esf:*"
  "outputs":
  - "args":
      "api_key": "..."
      "elasticsearch_url": "https://terraform-8b3bac.es.eu-central-1.aws.cloud.es.io"
      "es_datastream_name": "logs-esf.cloudwatch-default"
    "type": "elasticsearch"
  - "args":
      "api_key": "..."
      "elasticsearch_url": "https://terraform-2.es.europe-west4.gcp.elastic-cloud.com"
      "es_datastream_name": "logs-esf.cloudwatch-default"
    "type": "elasticsearch"
  "type": "cloudwatch-logs"
```

I sent a log event from this input.

If I look at Discover in both clouds, I can see that both outputs got my message:
- https://terraform-8b3bac.es.eu-central-1.aws.cloud.es.io:
![Screenshot from 2024-05-29 14-19-22](https://github.com/elastic/elastic-serverless-forwarder/assets/113898685/149dce2d-7ce2-4aaa-bf14-c73e1e0b2537)

- https://terraform-2.es.europe-west4.gcp.elastic-cloud.com:
![Screenshot from 2024-05-29 14-19-51](https://github.com/elastic/elastic-serverless-forwarder/assets/113898685/0d6238f9-28bb-4365-b5a4-2b549ffb8d8e)



### Example 2: Trying 2 `elasticsearch` outputs with the same destination

I have an input with two `elasticsearch` outputs that are the same:
```yaml
"inputs":
- "id": "arn:aws:logs:eu-west-2:627286350134:log-group:constanca-test-local-esf:*"
  "outputs":
  - "args":
      "api_key": "..."
      "elasticsearch_url": "https://terraform-8b3bac.es.eu-central-1.aws.cloud.es.io"
      "es_datastream_name": "logs-esf.cloudwatch-default"
    "type": "elasticsearch"
  - "args":
      "api_key": "..."
      "elasticsearch_url": "https://terraform-8b3bac.es.eu-central-1.aws.cloud.es.io"
      "es_datastream_name": "logs-esf.cloudwatch-default"
    "type": "elasticsearch"
  "type": "cloudwatch-logs"
```

This case fails, since we cannot have duplicated outputs (that is, output with the same destination for the same input):

```logs
[ERROR] ConfigFileException: An error occurred while applying output configuration at position 2 for input arn:aws:logs:eu-west-2:627286350134:log-group:constanca-test-local-esf:*: Duplicated output destination https://terraform-8b3bac.es.eu-central-1.aws.cloud.es.io for type elasticsearch
Traceback (most recent call last):
  File "/var/task/handlers/aws/utils.py", line 63, in wrapper
    return func(lambda_event, lambda_context)
  File "/var/task/handlers/aws/utils.py", line 98, in wrapper
    raise e
  File "/var/task/handlers/aws/utils.py", line 82, in wrapper
    return func(lambda_event, lambda_context)
  File "/var/task/handlers/aws/handler.py", line 74, in lambda_handler
    raise ConfigFileException(e)
```

### Example 3: Checking message body in replay queue

The message body caused by an ingestion error should contain the `output_destination` (instead of `output_type` like before). I am causing the placement of the message in the replay queue by using wrong authentication:

```yaml
"inputs":
- "id": "arn:aws:logs:eu-west-2:627286350134:log-group:constanca-test-local-esf:*"
  "outputs":
  - "args":
      "api_key": "<Wrong API Key"
      "elasticsearch_url": "https://terraform-8b3bac.es.eu-central-1.aws.cloud.es.io"
      "es_datastream_name": "logs-esf.cloudwatch-default"
    "type": "elasticsearch"
```

Message in the replay queue:

```json
{"output_destination":"https://terraform-8b3bac.es.eu-central-1.aws.cloud.es.io","output_args":{"es_datastream_name":"logs-esf.cloudwatch-default"},"event_payload":...
```
