### PR TITLE
Removed '$' sign from region check in publish_lambda.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ### v1.17.1 - 2024/09/23
 ##### Bug fixes
 * Cache EC2:DescribeRegion API response to avoid throttling and improve performance [803](https://github.com/elastic/elastic-serverless-forwarder/pull/803).
-* Fixed deployment script bug that always set S3 region to `gov` [#727](https://github.com/elastic/elastic-serverless-forwarder/pull/727).
 
 ### v1.17.0 - 2024/07/10
 ##### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.15.0 - 2024/06/05
+##### Bug fixes
+* Fixed deployment script bug that always set S3 region to `gov` [#727](https://github.com/elastic/elastic-serverless-forwarder/pull/727).
+
 ### v1.14.0 - 2024/05/07
 ##### Bug fixes
 * Report misconfigured input ids as an error instead of warning, and place those messages in the replaying queue [#711](https://github.com/elastic/elastic-serverless-forwarder/pull/711).

--- a/publish_lambda.sh
+++ b/publish_lambda.sh
@@ -42,7 +42,7 @@ trap 'rm -rf ${TMPDIR}' EXIT
 aws s3api get-bucket-location --bucket "${BUCKET}" --region "${REGION}" || aws s3api create-bucket --acl private --bucket "${BUCKET}" --region "${REGION}" --create-bucket-configuration LocationConstraint="${REGION}"
 
 # Check if region is in AWS GovCloud and create bucket arn
-if [[ ${REGION} == *"$gov"* ]]; then
+if [[ ${REGION} == *"gov"* ]]; then
   BUCKET_ARN="arn:aws-us-gov:s3:::${BUCKET}"
   AWS_OR_AWS_GOV="aws-us-gov"
 else


### PR DESCRIPTION
Bug

## What does this PR do?

Fixed bug in the `publish_lambda.sh` script which always set up `gov` as bucket region.

## Why is it important?

Deployment script only works for `gov` regions in current state

## Checklist

- [~~] My code follows the style guidelines of this project
- [~~] I have commented my code, particularly in hard-to-understand areas
- [~~] I have made corresponding changes to the documentation
- [~~] I have made corresponding change to the default configuration files
- [~~] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md`

## Author's Checklist

## How to test this PR locally

Use deployment script to deploy Lambda.

## Related issues
Closes #726 

## Use cases


## Screenshots


## Logs

