### PR TITLE
[Documentation] Add reference to ESF terraform

### DIFF
--- a/docs/en/aws-deploy-elastic-serverless-forwarder.asciidoc
+++ b/docs/en/aws-deploy-elastic-serverless-forwarder.asciidoc
@@ -311,7 +311,7 @@ There are several deployment methods available via the {aws} Serverless Applicat
 
 * <<aws-serverless-forwarder-deploy-console>>
 * <<aws-serverless-forwarder-deploy-cloudformation>>
-* <<aws-serverless-forwarder-deploy-terraform>>
+* <<aws-serverless-forwarder-deploy-sar-terraform>>
 
 NOTE: To deploy the forwarder directly without using SAR, refer to <<aws-serverless-forwarder-direct-deploy>>
 
@@ -397,8 +397,8 @@ aws serverlessrepo list-application-versions --application-id arn:aws:serverless
 NOTE: Starting from **v1.4.0**, if you want to update the Events settings for the forwarder, you do not need to manually delete existing settings before applying new settings.
 
 [discrete]
-[[aws-serverless-forwarder-deploy-terraform]]
-=== Deploy using Terraform
+[[aws-serverless-forwarder-deploy-sar-terraform]]
+=== Deploy the SAR using Terraform
 
 . Save the following yaml content as `sar-application.tf` and fill in the correct parameters according to <<aws-serverless-forwarder-define-deploy-parameters>>:
 +

--- a/docs/en/aws-deploy-elastic-serverless-forwarder.asciidoc
+++ b/docs/en/aws-deploy-elastic-serverless-forwarder.asciidoc
@@ -398,7 +398,7 @@ NOTE: Starting from **v1.4.0**, if you want to update the Events settings for th
 
 [discrete]
 [[aws-serverless-forwarder-deploy-sar-terraform]]
-=== Deploy the SAR using Terraform
+=== Deploy from SAR using Terraform
 
 . Save the following yaml content as `sar-application.tf` and fill in the correct parameters according to <<aws-serverless-forwarder-define-deploy-parameters>>:
 +

--- a/docs/en/aws-deploy-elastic-serverless-forwarder.asciidoc
+++ b/docs/en/aws-deploy-elastic-serverless-forwarder.asciidoc
@@ -19,8 +19,7 @@ To deploy Elastic Serverless Forwarder, you have to:
 [discrete]
 [[aws-serverless-forwarder-deploy-prereq]]
 == Prerequisites
-This documentation assumes you have some familiarity with {aws} services and you have correctly created and configured the necessary {aws} objects. For example, if you want to use an Amazon S3 (via SQS event notifications) input then you must ensure that you have enabled AWS VPC flow logs to be sent to that bucket, and created an SQS queue to receive those logs. For more information, refer to the relevant https://docs.aws.amazon.com/[{aws} docs].
-
+This documentation assumes you have some familiarity with {aws} services, and you have correctly created and configured the necessary {aws} objects.
 // Need more details on pre-reqs for other input types
 
 NOTE: This page describes the basic steps required to deploy Elastic Serverless
@@ -180,6 +179,8 @@ inputs:
           ssl_assert_fingerprint: "22:F7:FB:84:1D:43:3E:E7:BB:F9:72:F3:D8:97:AD:7C:86:E3:08:42" #optional
 ----
 
+WARNING: All versions up to 1.14.0 (included) only allow one output per type. So if the `output.type` chosen by a user is `elasticsearch`, then the user can only configure one output for it.
+
 [discrete]
 [[s3-config-file-fields]]
 === Fields
@@ -210,7 +211,7 @@ The type of the forwarding target output. Currently only the following outputs a
  * `elasticsearch`
  * preview:[] `logstash`
 
-If {ls} is chosen as an output, Elastic Serverless Forwarder expects the {logstash-ref}/plugins-inputs-elastic_serverless_forwarder.html[`elastic_serverless_forwarder`] Logstash input to be installed, enabled, and properly configured. For more information about installing Logstash plugins, refer to the {logstash-ref}/working-with-plugins.html#installing-plugins[Logstash documentation].
+Each type can only be used for a maximum of one output up to and including 1.14.0 version. If {ls} is chosen as an output, Elastic Serverless Forwarder expects the {logstash-ref}/plugins-inputs-elastic_serverless_forwarder.html[`elastic_serverless_forwarder`] Logstash input to be installed, enabled, and properly configured. For more information about installing Logstash plugins, refer to the {logstash-ref}/working-with-plugins.html#installing-plugins[Logstash documentation].
 
 `inputs.[].outputs.[].args`:
 Custom init arguments for the specified forwarding target output.
@@ -294,6 +295,13 @@ Leave both parameters blank if you don't want the forwarder to belong to any spe
 If the Elastic Serverless Forwarder is attached to a VPC, you need to https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html[create VPC endpoints] for S3 and SQS, and for *every* service you define as an input for the forwarder. S3 and SQS VPC endpoints are always required for reading the `config.yaml` uploaded to S3 and managing the continuing queue and the replay queue, regardless of the <<aws-serverless-forwarder-inputs>> used. If you use <<aws-serverless-forwarder-inputs-cloudwatch>>, you need to create a VPC endpoint for EC2, too.
 
 NOTE: Refer to the {cloud}/ec-traffic-filtering-vpc.html[AWS PrivateLink traffic filters] documentation to find your VPC endpoint ID and the hostname to use in the `config.yml` in order to access your Elasticsearch cluster over PrivateLink.
+
+[discrete]
+[[aws-serverless-forwarder-deploy-terraform]]
+== Deploy Elastic Serverless Forwarder from Terraform
+
+The terraform files to deploy ESF can be found in https://github.com/elastic/terraform-elastic-esf[`esf-terraform` repository]. There are two requirements to deploy these files: https://curl.se/download.html[curl] and https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli[terraform]. Refer to the https://github.com/elastic/terraform-elastic-esf/blob/main/README.md[README file] to learn how to use it.
+
 
 [discrete]
 [[aws-serverless-forwarder-deploy-sar]]


### PR DESCRIPTION
**WARNING**: Do not merge before [ESF terraform](https://github.com/elastic/terraform-elastic-esf/tree/main) is public.

## What does this PR do?


We need to add a reference to [ESF terraform](https://github.com/elastic/terraform-elastic-esf/tree/main) repository for it to go public.


## How to test this PR locally

To see the documents, [run the command from elastic docs for a local repo](https://github.com/elastic/docs?tab=readme-ov-file#for-a-local-repo):

```bash
<local-path-to-elastic-docs-repo>/docs/build_docs --doc <local-path-to-elastic-serverless-forwarder-repo>/docs/en/index.asciidoc --open
```


## Related issues

Relates to https://github.com/elastic/terraform-elastic-esf/issues/8.

