### PR TITLE
ci: fix test coverage reporting

### DIFF
--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   actions: read
   checks: write
+  pull-requests: write
 
 jobs:
   report:


### PR DESCRIPTION
## What does this PR do?

Add pull-requests permissions to the coverage reporting in the `test-reporter` can do its job.

## Why is it important?

Fixes the required permissions otherwise the reporting will fail, see https://github.com/elastic/elastic-serverless-forwarder/actions/runs/11146807195/job/30979622250

<img width="941" alt="image" src="https://github.com/user-attachments/assets/b9861e6d-74ad-4744-ae2a-6f4ed9df1e8e">


That's something we have discovered through our Observability CICD with OTEL for GH actions that alerted us that something was not right

<img width="1374" alt="image" src="https://github.com/user-attachments/assets/5224f35a-b9ce-4218-9c81-7d9625aedf39">
