### PR TITLE
[s3-sqs] Log a Lambda event summary on exception

### DIFF
--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -142,7 +142,7 @@ def summarize_lambda_event(event: dict[str, Any], max_records: int = 10) -> dict
     """
     Summarize the lambda event to include only the most relevant information.
     """
-    summary = {}
+    summary: dict[str, Any] = {}
 
     try:
         records = event.get("Records", [])

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -203,11 +203,11 @@ def summarize_lambda_event(event: dict[str, Any], max_records: int = 10) -> dict
                 # Update the summary with the new information.
                 summary["aws:sqs"] = aws_sqs_summary
 
-    except Exception as e:
-        shared_logger.exception("error summarizing lambda event", exc_info=e)
+    except Exception as exc:
+        shared_logger.exception("error summarizing lambda event", exc_info=exc)
         # We add an error message to the summary so users know if the summary
         # is incomplete.
-        summary["error"] = str(e)
+        summary["error"] = str(exc)
 
     return summary
 

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -154,7 +154,7 @@ def summarize_lambda_event(event: dict[str, Any], max_records: int = 10) -> dict
             if event_source == "aws:sqs":
                 aws_sqs_summary = summary.get(
                     "aws:sqs",
-                    # if `aws:sqs` key does not exist yet, 
+                    # if `aws:sqs` key does not exist yet,
                     # we initialize the summary.
                     {
                         "total_records": 0,

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -129,7 +129,7 @@ def wrap_try_except(
                 "exception raised",
                 exc_info=e,
                 extra={
-                    "summary": summarize_lambda_event(lambda_event),
+                    "summary": summarize_lambda_event(lambda_event, max_records=20),
                 },
             )
 

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -173,7 +173,7 @@ def summarize_lambda_event(event: dict[str, Any], max_records: int = 10) -> dict
                 for r in notifications["Records"]:
                     # we only include the s3 object key in the summary.
                     #
-                    # Here is an example of a record:
+                    # Here is an example of a notification record:
                     #
                     # {
                     #   "Records": [
@@ -197,8 +197,11 @@ def summarize_lambda_event(event: dict[str, Any], max_records: int = 10) -> dict
 
                     # We stop adding records to the summary once we reach
                     # the `max_records` limit.
-                    if len(aws_sqs_summary[first_records_key]) < max_records:
-                        aws_sqs_summary[first_records_key].append(r.get("s3"))
+                    if len(aws_sqs_summary[first_records_key]) == max_records:
+                        break
+
+                    # Add the s3 object key to the summary.
+                    aws_sqs_summary[first_records_key].append(r.get("s3"))
 
                 # Update the summary with the new information.
                 summary["aws:sqs"] = aws_sqs_summary

--- a/tests/handlers/aws/test_utils.py
+++ b/tests/handlers/aws/test_utils.py
@@ -471,7 +471,7 @@ class TestSummarizeLambdaEvent(TestCase):
         event = {
             "Records": [
                 {
-                    "body": '{"Records":[{"awsRegion":"eu-west-1","eventName":"ObjectCreated:Put","eventSource":"aws:s3","eventVersion":"2.1","s3":{"bucket":{"arn":"arn:aws:s3:::mbranca-esf-data","name":"mbranca-esf-data"},"object":{"key":"AWSLogs/627286350134/CloudTrail-Digest/"}}}]}',
+                    "body": '{"Records":[{"awsRegion":"eu-west-1","eventName":"ObjectCreated:Put","eventSource":"aws:s3","eventVersion":"2.1","s3":{"bucket":{"arn":"arn:aws:s3:::mbranca-esf-data","name":"mbranca-esf-data"},"object":{"key":"AWSLogs/627286350134/CloudTrail-Digest/"}}}]}',  # noqa: E501
                     "eventSource": "aws:sqs",
                 }
             ]
@@ -497,7 +497,7 @@ class TestSummarizeLambdaEvent(TestCase):
         event = {
             "Records": [
                 {
-                    "body": '{"Records":[{"awsRegion":"eu-west-1","eventName":"ObjectCreated:Put","eventSource":"aws:s3","eventVersion":"2.1","s3":{"bucket":{"arn":"arn:aws:s3:::mbranca-esf-data","name":"mbranca-esf-data"},"object":{"key":"AWSLogs/123456789012/1.log"}}},{"awsRegion":"eu-west-1","eventName":"ObjectCreated:Put","eventSource":"aws:s3","eventVersion":"2.1","s3":{"bucket":{"arn":"arn:aws:s3:::mbranca-esf-data","name":"mbranca-esf-data"},"object":{"key":"AWSLogs/123456789012/2.log"}}}]}',
+                    "body": '{"Records":[{"awsRegion":"eu-west-1","eventName":"ObjectCreated:Put","eventSource":"aws:s3","eventVersion":"2.1","s3":{"bucket":{"arn":"arn:aws:s3:::mbranca-esf-data","name":"mbranca-esf-data"},"object":{"key":"AWSLogs/123456789012/1.log"}}},{"awsRegion":"eu-west-1","eventName":"ObjectCreated:Put","eventSource":"aws:s3","eventVersion":"2.1","s3":{"bucket":{"arn":"arn:aws:s3:::mbranca-esf-data","name":"mbranca-esf-data"},"object":{"key":"AWSLogs/123456789012/2.log"}}}]}',  # noqa: E501
                     "eventSource": "aws:sqs",
                 }
             ]

--- a/tests/handlers/aws/test_utils.py
+++ b/tests/handlers/aws/test_utils.py
@@ -553,4 +553,4 @@ class TestSummarizeLambdaEvent(TestCase):
 
         summary = summarize_lambda_event(event)
 
-        assert summary == {'error': 'unexpected character: line 1 column 1 (char 0)'}
+        assert summary == {"error": "unexpected character: line 1 column 1 (char 0)"}

--- a/tests/handlers/aws/test_utils.py
+++ b/tests/handlers/aws/test_utils.py
@@ -465,6 +465,8 @@ class TestGetLambdaRegion(TestCase):
 @pytest.mark.unit
 class TestSummarizeLambdaEvent(TestCase):
 
+    max_records = 42
+
     def test_with_single_s3_sqs_record(self) -> None:
         from handlers.aws.utils import summarize_lambda_event
 
@@ -477,12 +479,12 @@ class TestSummarizeLambdaEvent(TestCase):
             ]
         }
 
-        summary = summarize_lambda_event(event=event)
+        summary = summarize_lambda_event(event=event, max_records=self.max_records)
 
         assert summary == {
             "aws:sqs": {
                 "total_records": 1,
-                "records": [
+                f"first_{self.max_records}_records": [
                     {
                         "bucket": {"arn": "arn:aws:s3:::mbranca-esf-data", "name": "mbranca-esf-data"},
                         "object": {"key": "AWSLogs/627286350134/CloudTrail-Digest/"},
@@ -504,12 +506,12 @@ class TestSummarizeLambdaEvent(TestCase):
         }
 
         with self.subTest("no limits"):
-            summary = summarize_lambda_event(event=event)
+            summary = summarize_lambda_event(event=event, max_records=self.max_records)
 
             assert summary == {
                 "aws:sqs": {
                     "total_records": 2,
-                    "records": [
+                    f"first_{self.max_records}_records": [
                         {
                             "bucket": {"arn": "arn:aws:s3:::mbranca-esf-data", "name": "mbranca-esf-data"},
                             "object": {"key": "AWSLogs/123456789012/1.log"},
@@ -528,7 +530,7 @@ class TestSummarizeLambdaEvent(TestCase):
             assert summary == {
                 "aws:sqs": {
                     "total_records": 2,
-                    "records": [
+                    "first_1_records": [
                         {
                             "bucket": {"arn": "arn:aws:s3:::mbranca-esf-data", "name": "mbranca-esf-data"},
                             "object": {"key": "AWSLogs/123456789012/1.log"},
@@ -551,4 +553,4 @@ class TestSummarizeLambdaEvent(TestCase):
 
         summary = summarize_lambda_event(event)
 
-        assert summary == {}
+        assert summary == {'error': 'unexpected character: line 1 column 1 (char 0)'}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

If there is an exception when processing a lambda event from the `s3-sqs` input, ESF summarizes the lambda event and adds the summary as extra information to the exception log message.

The summary contains the essential elements for the lambda event. For the `s3-sqs` input, it includes the bucket ARN and the object key. The summary limits the number of records to `max_records`.

ESF currently supports lambda event summary for `s3-sqs` only. We want to hear users' feedback before making additional changes or extending the summary to other input types.

## Why is it important?

For some error classes (e.g., encoding errors), knowing the S3 objects in flight in the lambda event helps speed up investigation and troubleshooting.

Users can achieve the same goal by enabling APM, but this extra log helps those users who do not or won't use APM for any reason.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md` and updated `share/version.py`, if my change requires a new release.


<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Deploy ESF and send an SQS message with a S3 that points to a non-existent S3 object:

```sh
aws sqs send-message \
    --queue-url https://sqs.eu-west-1.amazonaws.com/627286350134/mbranca-esf-notifications \
    --message-body '{"Records":[{"awsRegion":"eu-west-1","eventTime": "2024-01-31T19:06:30.680Z","eventName":"ObjectCreated:Put","eventSource":"aws:s3","eventVersion":"2.1","s3":{"bucket":{"arn":"arn:aws:s3:::mbranca-esf-data","name":"mbranca-esf-data"},"object":{"key":"AWSLogs/123456/I-do-not-exist"}}}]}'
```

<!-- Recommended
## Related issues
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-
-->


<!-- Recommended
## Use cases
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
## Screenshots
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

Here is a sample log with the lambda event summary:

```json
{
    "@timestamp": "2024-11-29T12:06:05.404Z",
    "log.level": "error",
    "message": "exception raised",
    "ecs": {
        "version": "1.6.0"
    },
    "error": {
        "message": "An error occurred (404) when calling the HeadObject operation: Not Found",
        "stack_trace": "  File \"/var/task/handlers/aws/utils.py\", line 103, in wrapper\n    return func(lambda_event, lambda_context)\n  File \"/var/task/handlers/aws/handler.py\", line 532, in lambda_handler\n    for es_event, last_ending_offset, last_event_expanded_offset, current_s3_record in _handle_s3_sqs_event(\n  File \"/var/task/handlers/aws/s3_sqs_trigger.py\", line 141, in _handle_s3_sqs_event\n    for log_event, starting_offset, ending_offset, event_expanded_offset in events:\n  File \"/var/task/storage/s3.py\", line 78, in get_by_lines\n    s3_object_head = self._s3_client.head_object(Bucket=self._bucket_name, Key=self._object_key)\n  File \"/var/task/botocore/client.py\", line 565, in _api_call\n    return self._make_api_call(operation_name, kwargs)\n  File \"/var/task/elasticapm/instrumentation/packages/base.py\", line 213, in call_if_sampling\n    return self.call(module, method, wrapped, instance, args, kwargs)\n  File \"/var/task/elasticapm/instrumentation/packages/botocore.py\", line 106, in call\n    result = wrapped(*args, **kwargs)\n  File \"/var/task/botocore/client.py\", line 1017, in _make_api_call\n    raise error_class(parsed_response, operation_name)\n",
        "type": "ClientError"
    },
    "log": {
        "logger": "root",
        "origin": {
            "file": {
                "line": 128,
                "name": "utils.py"
            },
            "function": "wrapper"
        },
        "original": "exception raised"
    },
    "process": {
        "name": "MainProcess",
        "pid": 8,
        "thread": {
            "id": 139632879478592,
            "name": "MainThread"
        }
    },
    "service": {
        "name": "mbranca-esf-ApplicationElasticServerlessForwarder-0VuQ7x2yawGZ"
    },
    "span": {
        "id": "4a348c93af0ca023"
    },
    "summary": {
        "aws:sqs": {
            "records": [
                {
                    "bucket": {
                        "arn": "arn:aws:s3:::mbranca-esf-data",
                        "name": "mbranca-esf-data"
                    },
                    "object": {
                        "key": "AWSLogs/123456/I-do-not-exist"
                    }
                }
            ],
            "total_records": 1
        }
    },
    "trace": {
        "id": "88556e9d3f65fc709e53555b64b44a66"
    },
    "transaction": {
        "id": "c8dc45b175c39628"
    }
}
```

