### PR TITLE
[docs] Clean up cross-repo links

### DIFF
--- a/docs/reference/aws-deploy-elastic-serverless-forwarder.md
+++ b/docs/reference/aws-deploy-elastic-serverless-forwarder.md
@@ -208,7 +208,7 @@ The type of the forwarding target output. Currently only the following outputs a
 * `elasticsearch`
 * [preview] `logstash`
 
-Each type can only be used for a maximum of one output up to and including 1.14.0 version. If {{ls}} is chosen as an output, Elastic Serverless Forwarder expects the [`elastic_serverless_forwarder`](logstash://docs/reference/plugins-inputs-elastic_serverless_forwarder.md) Logstash input to be installed, enabled, and properly configured. For more information about installing Logstash plugins, refer to the [Logstash documentation](logstash://docs/reference/working-with-plugins.md#installing-plugins).
+Each type can only be used for a maximum of one output up to and including 1.14.0 version. If {{ls}} is chosen as an output, Elastic Serverless Forwarder expects the [`elastic_serverless_forwarder`](logstash://reference/plugins-inputs-elastic_serverless_forwarder.md) Logstash input to be installed, enabled, and properly configured. For more information about installing Logstash plugins, refer to the [Logstash documentation](logstash://reference/working-with-plugins.md#installing-plugins).
 
 `inputs.[].outputs.[].args`: Custom init arguments for the specified forwarding target output.
 

--- a/docs/reference/aws-elastic-serverless-forwarder-configuration.md
+++ b/docs/reference/aws-elastic-serverless-forwarder-configuration.md
@@ -110,7 +110,7 @@ arn:aws:secretsmanager:AWS_REGION:AWS_ACCOUNT_ID:secret:SECRET_NAME:SECRET_KEY
 
 ## Route AWS service logs [aws-serverless-route-service-logs]
 
-For `S3 SQS Event Notifications` inputs, the Elastic Serverless Forwarder supports automatic routing of several AWS service logs to the corresponding [integration data streams](integration-docs://docs/reference/index.md) for further processing and storage in the {{es}} cluster.
+For `S3 SQS Event Notifications` inputs, the Elastic Serverless Forwarder supports automatic routing of several AWS service logs to the corresponding [integration data streams](integration-docs://reference/index.md) for further processing and storage in the {{es}} cluster.
 
 
 ### Automatic routing [aws-serverless-automatic-routing]
@@ -233,7 +233,7 @@ To change this configuration option, set `inputs.[].json_content_type` to one of
 * **disabled**: instructs the forwarder not to attempt any automatic JSON content discovery and instead treat the content as plain text, which improves the parsing performance.
 
 ::::{note}
-JSON content is still stored in Elasticsearch as field type `text`. No automatic JSON expansion is performed by the forwarder; this can be achieved using the [JSON processor](elasticsearch://docs/reference/ingestion-tools/enrich-processor/json-processor.md) in an ingest pipeline in Elasticsearch.
+JSON content is still stored in Elasticsearch as field type `text`. No automatic JSON expansion is performed by the forwarder; this can be achieved using the [JSON processor](elasticsearch://reference/ingestion-tools/enrich-processor/json-processor.md) in an ingest pipeline in Elasticsearch.
 ::::
 
 
@@ -389,7 +389,7 @@ Note that you should escape the opening square bracket (`[`) in the regular expr
 | `false` | `before` | Consecutive lines that don’t match the pattern are prepended to the next line that does match. | ![Lines a c b d e b become "acb" and "deb"](../images/true-before-multi.png "") |
 
 ::::{note}
-The `after` setting is equivalent to `previous` in [{{ls}}](logstash://docs/reference/plugins-codecs-multiline.md), and `before` is equivalent to `next`.
+The `after` setting is equivalent to `previous` in [{{ls}}](logstash://reference/plugins-codecs-multiline.md), and `before` is equivalent to `next`.
 ::::
 
 


### PR DESCRIPTION
Follow up to #867 

When using cross-repo links, the path should be relative to the `docset.yml` not the full path within the repo ([updated docs-builder docs](https://elastic.github.io/docs-builder/syntax/links/#cross-repository-links)).