### PR TITLE
Improve multi_line debug logs

### DIFF
--- a/storage/decorator.py
+++ b/storage/decorator.py
@@ -88,7 +88,7 @@ def multi_line(func: StorageDecoratorCallable[ProtocolStorageType]) -> StorageDe
             for data, starting_offset, ending_offset, newline, event_expanded_offset in iterator:
                 assert isinstance(data, bytes)
 
-                shared_logger.debug("multi_line skipped", extra={"offset": ending_offset})
+                shared_logger.debug("no multi_line processor configured, processing as single line", extra={"offset": ending_offset})
 
                 yield data, starting_offset, ending_offset, newline, event_expanded_offset
         else:

--- a/storage/decorator.py
+++ b/storage/decorator.py
@@ -88,7 +88,9 @@ def multi_line(func: StorageDecoratorCallable[ProtocolStorageType]) -> StorageDe
             for data, starting_offset, ending_offset, newline, event_expanded_offset in iterator:
                 assert isinstance(data, bytes)
 
-                shared_logger.debug("no multi_line processor configured, processing as single line", extra={"offset": ending_offset})
+                shared_logger.debug(
+                    "no multi_line processor configured, processing as single line", extra={"offset": ending_offset}
+                )
 
                 yield data, starting_offset, ending_offset, newline, event_expanded_offset
         else:


### PR DESCRIPTION
Fixes https://github.com/elastic/elastic-serverless-forwarder/issues/870

## Why is it important?

The current multi_line skipped message is a bit confusing and may lead a customer to believe the event has been skipped.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md` and updated `share/version.py`, if my change requires a new release.