### PR TITLE
[docs] Remove reliance on temporary redirects

### DIFF
--- a/docs/reference/aws-elastic-serverless-forwarder-configuration.md
+++ b/docs/reference/aws-elastic-serverless-forwarder-configuration.md
@@ -233,7 +233,7 @@ To change this configuration option, set `inputs.[].json_content_type` to one of
 * **disabled**: instructs the forwarder not to attempt any automatic JSON content discovery and instead treat the content as plain text, which improves the parsing performance.
 
 ::::{note}
-JSON content is still stored in Elasticsearch as field type `text`. No automatic JSON expansion is performed by the forwarder; this can be achieved using the [JSON processor](elasticsearch://reference/ingestion-tools/enrich-processor/json-processor.md) in an ingest pipeline in Elasticsearch.
+JSON content is still stored in Elasticsearch as field type `text`. No automatic JSON expansion is performed by the forwarder; this can be achieved using the [JSON processor](elasticsearch://reference/enrich-processor/json-processor.md) in an ingest pipeline in Elasticsearch.
 ::::
 
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -11,7 +11,7 @@ The Elastic Serverless Forwarder is an Amazon Web Services (AWS) Lambda function
 The Elastic Serverless Forwarder works with {{stack}} 7.17 and later.
 
 ::::{important}
-Using Elastic Serverless Forwarder may result in additional charges. To learn how to minimize additional charges, refer to [Preventing unexpected costs](docs-content://troubleshoot/deployments/esf/elastic-serverless-forwarder.md#preventing-unexpected-costs).
+Using Elastic Serverless Forwarder may result in additional charges. To learn how to minimize additional charges, refer to [Preventing unexpected costs](docs-content://troubleshoot/ingest/elastic-serverless-forwarder.md#preventing-unexpected-costs).
 ::::
 
 
@@ -145,5 +145,5 @@ The same message can go back to the replay queue up to three times. After reachi
 
 * [Deploy Elastic Serverless Forwarder](/reference/aws-deploy-elastic-serverless-forwarder.md)
 * [Configuration options](/reference/aws-elastic-serverless-forwarder-configuration.md)
-* [Troubleshooting](docs-content://troubleshoot/deployments/esf/elastic-serverless-forwarder.md)
+* [Troubleshooting](docs-content://troubleshoot/ingest/elastic-serverless-forwarder.md)
 


### PR DESCRIPTION
Related to https://github.com/elastic/docs-content/pull/914

Removes reliance on temporary redirects in the docs-content repo.