### PR TITLE
fix issue: logstash shipper does not clear event buffer after sending data(#880)

### DIFF
--- a/shippers/logstash.py
+++ b/shippers/logstash.py
@@ -126,7 +126,7 @@ class LogstashShipper:
         if len(self._events_batch) > 0:
             self._send()
 
-        self._events_batch = []
+        self._events_batch.clear()
 
         return
 
@@ -143,7 +143,9 @@ class LogstashShipper:
 
             if response.status_code == 401:
                 raise RequestException("Authentication error")
+            
             self._events_batch.clear()
+
         except RequestException as e:
             shared_logger.error(
                 f"logstash shipper encountered an error while publishing events to logstash. Error: {str(e)}"

--- a/shippers/logstash.py
+++ b/shippers/logstash.py
@@ -143,6 +143,7 @@ class LogstashShipper:
 
             if response.status_code == 401:
                 raise RequestException("Authentication error")
+            self._events_batch.clear()
         except RequestException as e:
             shared_logger.error(
                 f"logstash shipper encountered an error while publishing events to logstash. Error: {str(e)}"

--- a/shippers/logstash.py
+++ b/shippers/logstash.py
@@ -143,7 +143,7 @@ class LogstashShipper:
 
             if response.status_code == 401:
                 raise RequestException("Authentication error")
-            
+
             self._events_batch.clear()
 
         except RequestException as e:

--- a/tests/shippers/test_logstash.py
+++ b/tests/shippers/test_logstash.py
@@ -163,3 +163,23 @@ class TestLogstashShipper(TestCase):
         assert logstash_shipper._events_batch == [event]
         logstash_shipper.flush()
         assert logstash_shipper._events_batch == []
+
+    @responses.activate
+    def test_buffer_handling_at_capacity(self) -> None:
+        url = "http://logstash_url"
+        responses.put(url=url, status=200)
+        responses.put(url=url, status=200)
+        responses.put(url=url, status=200)
+
+        logstash_shipper = LogstashShipper(logstash_url=url, max_batch_size=2)
+        event = deepcopy(_dummy_event)
+        
+        logstash_shipper.send(event)  # this should not trigger the send
+        assert logstash_shipper._events_batch == [event]
+        logstash_shipper.send(event)  # this should trigger the send and empty the buffer
+        assert logstash_shipper._events_batch == []
+        logstash_shipper.send(event) # this should not trigger the send
+        assert logstash_shipper._events_batch == [event]
+        logstash_shipper.flush() # this should trigger the send and empty the buffer
+        assert logstash_shipper._events_batch == []
+    

--- a/tests/shippers/test_logstash.py
+++ b/tests/shippers/test_logstash.py
@@ -182,4 +182,3 @@ class TestLogstashShipper(TestCase):
         assert logstash_shipper._events_batch == [event]
         logstash_shipper.flush() # this should trigger the send and empty the buffer
         assert logstash_shipper._events_batch == []
-    

--- a/tests/shippers/test_logstash.py
+++ b/tests/shippers/test_logstash.py
@@ -173,12 +173,12 @@ class TestLogstashShipper(TestCase):
 
         logstash_shipper = LogstashShipper(logstash_url=url, max_batch_size=2)
         event = deepcopy(_dummy_event)
-        
+
         logstash_shipper.send(event)  # this should not trigger the send
         assert logstash_shipper._events_batch == [event]
         logstash_shipper.send(event)  # this should trigger the send and empty the buffer
         assert logstash_shipper._events_batch == []
-        logstash_shipper.send(event) # this should not trigger the send
+        logstash_shipper.send(event)  # this should not trigger the send
         assert logstash_shipper._events_batch == [event]
-        logstash_shipper.flush() # this should trigger the send and empty the buffer
+        logstash_shipper.flush()  # this should trigger the send and empty the buffer
         assert logstash_shipper._events_batch == []


### PR DESCRIPTION
fix issue: logstash shipper does not clear event buffer after sending data(#880), this leads to sending huge duplicated data

In the file of logstash shipper, in _send function, event buffer should have been cleared after successfully sending over the data, but it did not.

So I simply added one statement for clearing the buffer. 

Closes #880