### PR TITLE
chore: add make commands to package and clean zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.egg
 *.db
 *.pid
+*.zip
 .coverage*
 .DS_Store
 .idea

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,18 @@ isort:  ## Run isort in the project on the host
 mypy: ## Run mypy in the project on the host
 	tests/scripts/${SCRIPTS_BASE_DIR}mypy.sh
 
+package:
+	mkdir deps && \
+    pip install --target=./deps -r requirements.txt && \
+    cd ./deps && \
+    zip -r ../local_esf.zip . && \
+    cd .. && \
+    zip -r local_esf.zip main_aws.py handlers share storage shippers && \
+    rm -r ./deps
+
+clean:
+	rm -f local_esf.zip
+
 docker-test:  ## Run all tests on docker
 docker-test: SCRIPTS_BASE_DIR=docker/
 docker-test: test

--- a/Makefile
+++ b/Makefile
@@ -36,16 +36,17 @@ isort:  ## Run isort in the project on the host
 mypy: ## Run mypy in the project on the host
 	tests/scripts/${SCRIPTS_BASE_DIR}mypy.sh
 
-package:
+package: ## Package lambda by installing python dependencies matching x86_64
 	mkdir deps && \
-    pip install --target=./deps -r requirements.txt && \
+    pip install --target=./deps --platform manylinux2014_x86_64 --implementation cp --python-version 3.12 --only-binary=:all: --upgrade -r requirements.txt && \
     cd ./deps && \
     zip -r ../local_esf.zip . && \
     cd .. && \
     zip -r local_esf.zip main_aws.py handlers share storage shippers && \
     rm -r ./deps
 
-clean:
+clean: ## cleanup any leftover resources
+	rm -f -r ./deps
 	rm -f local_esf.zip
 
 docker-test:  ## Run all tests on docker

--- a/dev-corner/how-to-test-locally/README.md
+++ b/dev-corner/how-to-test-locally/README.md
@@ -1,16 +1,37 @@
-This is just an example of how to build and run ESF locally.
+This document contains details about how to build ESF Lambda locally.
+Once built, the Lambda can be deployed to validate functionality.
 
-## Requirements
+## Building lambda
+
+To build the Lambda, you may use one of the options below,
+
+### Using Makefile
+
+To build,
+
+```shell
+make package
+```
+
+This will generate a Lambda zip named `local_esf.zip`.
+
+To clean up any leftover resources,
+
+```shell
+make clean
+```
+
+### Using Task file
+
+#### Requirements
 
 - [Terraform](https://www.terraform.io/)
 - (Optional) [Taskfile](https://taskfile.dev/installation/)
 
 
-## Steps
+#### Building
 
 **Important note**: ESF dependencies have been tested on architecture `x86_64`. Make sure to use it as well.
-
-### Step 1: Build your dependencies zip file
 
 You can build your own, or you can choose to run:
 ```bash
@@ -24,12 +45,11 @@ You can update the task variables in the `.env` file:
 - The name of the zip file, `FILENAME`.
 
 
-### Step 2: Run ESF terraform
+## Deploying Lambda
 
-Use the code in [ESF terraform repository](https://github.com/elastic/terraform-elastic-esf).
+Once Lambda zip is ready, you should use the code in [ESF terraform repository](https://github.com/elastic/terraform-elastic-esf).
 
 > **NOTE**: ESF lambda function is using architecture `x86_64`.
-
 
 Place your `local_esf.zip` (or `<FILENAME>` if you changed the value) in the same directory as ESF terraform.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-elastic-apm==6.19.0
+elastic-apm==6.23.0
 boto3==1.37.36
 ecs_logging==2.1.0
 elasticsearch==7.17.12


### PR DESCRIPTION
## What does this PR do?

Adds simple Make commands to package lambda zip locally. This is in addition to existing dev corner local testing guide [1]

To build lambda zip - `make package`
To clean it up - `make clean`

The zip is named `local_esf.zip`

## Why is it important?

This allows developers to package lambda without the need of extra tools.

[1] - https://github.com/elastic/elastic-serverless-forwarder/tree/main/dev-corner/how-to-test-locally