### PR TITLE
feat: add gzip compression to SQS replay events generated from CloudWatch

### DIFF
--- a/handlers/aws/cloudwatch_logs_trigger.py
+++ b/handlers/aws/cloudwatch_logs_trigger.py
@@ -10,7 +10,7 @@ from botocore.client import BaseClient as BotoBaseClient
 from share import ExpandEventListFromField, ProtocolMultiline, json_parser, shared_logger
 from storage import ProtocolStorage, StorageFactory
 
-from .utils import GZIP_ENCODING, get_account_id_from_arn, gzip_base64_encoded
+from .utils import GZIP_ENCODING, PAYLOAD_ENCODING_KEY, get_account_id_from_arn, gzip_base64_encoded
 
 
 def _from_awslogs_data_to_event(awslogs_data: str) -> Any:
@@ -56,7 +56,7 @@ def _handle_cloudwatch_logs_move(
             "originalLogGroup": {"StringValue": log_group_name, "DataType": "String"},
             "originalLogStream": {"StringValue": log_stream_name, "DataType": "String"},
             "originalEventTimestamp": {"StringValue": str(log_event["timestamp"]), "DataType": "Number"},
-            "payloadEncoding": {"StringValue": GZIP_ENCODING, "DataType": "String"},
+            PAYLOAD_ENCODING_KEY: {"StringValue": GZIP_ENCODING, "DataType": "String"},
         }
 
         if last_ending_offset is not None:

--- a/handlers/aws/cloudwatch_logs_trigger.py
+++ b/handlers/aws/cloudwatch_logs_trigger.py
@@ -10,7 +10,7 @@ from botocore.client import BaseClient as BotoBaseClient
 from share import ExpandEventListFromField, ProtocolMultiline, json_parser, shared_logger
 from storage import ProtocolStorage, StorageFactory
 
-from .utils import get_account_id_from_arn, gzip_base64_encoded
+from .utils import GZIP_ENCODING, get_account_id_from_arn, gzip_base64_encoded
 
 
 def _from_awslogs_data_to_event(awslogs_data: str) -> Any:
@@ -56,6 +56,7 @@ def _handle_cloudwatch_logs_move(
             "originalLogGroup": {"StringValue": log_group_name, "DataType": "String"},
             "originalLogStream": {"StringValue": log_stream_name, "DataType": "String"},
             "originalEventTimestamp": {"StringValue": str(log_event["timestamp"]), "DataType": "Number"},
+            "payloadEncoding": {"StringValue": GZIP_ENCODING, "DataType": "String"},
         }
 
         if last_ending_offset is not None:

--- a/handlers/aws/cloudwatch_logs_trigger.py
+++ b/handlers/aws/cloudwatch_logs_trigger.py
@@ -10,7 +10,7 @@ from botocore.client import BaseClient as BotoBaseClient
 from share import ExpandEventListFromField, ProtocolMultiline, json_parser, shared_logger
 from storage import ProtocolStorage, StorageFactory
 
-from .utils import get_account_id_from_arn
+from .utils import get_account_id_from_arn, gzip_base64_encoded
 
 
 def _from_awslogs_data_to_event(awslogs_data: str) -> Any:
@@ -70,9 +70,10 @@ def _handle_cloudwatch_logs_move(
                 "DataType": "Number",
             }
 
+        # forward compressed message to sqs queue
         sqs_client.send_message(
             QueueUrl=sqs_destination_queue,
-            MessageBody=log_event["message"],
+            MessageBody=gzip_base64_encoded(log_event["message"]),
             MessageAttributes=message_attributes,
         )
 

--- a/handlers/aws/handler.py
+++ b/handlers/aws/handler.py
@@ -23,6 +23,7 @@ from .utils import (
     CONFIG_FROM_PAYLOAD,
     GZIP_ENCODING,
     INTEGRATION_SCOPE_GENERIC,
+    PAYLOAD_ENCODING_KEY,
     ConfigFileException,
     TriggerTypeException,
     capture_serverless,
@@ -87,8 +88,8 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
         for replay_record in lambda_event["Records"]:
             event = json_parser(replay_record["body"])
 
-            if "messageAttributes" in replay_record and "payloadEncoding" in replay_record["messageAttributes"]:
-                if replay_record["messageAttributes"]["payloadEncoding"]["stringValue"] == GZIP_ENCODING:
+            if "messageAttributes" in replay_record and PAYLOAD_ENCODING_KEY in replay_record["messageAttributes"]:
+                if replay_record["messageAttributes"][PAYLOAD_ENCODING_KEY]["stringValue"] == GZIP_ENCODING:
                     event["event_payload"] = gzip_base64_decoded(event["event_payload"])
 
             input_id = event["event_input_id"]

--- a/handlers/aws/handler.py
+++ b/handlers/aws/handler.py
@@ -21,6 +21,7 @@ from .s3_sqs_trigger import _handle_s3_sqs_event, _handle_s3_sqs_move
 from .sqs_trigger import _handle_sqs_event, handle_sqs_move
 from .utils import (
     CONFIG_FROM_PAYLOAD,
+    GZIP_ENCODING,
     INTEGRATION_SCOPE_GENERIC,
     ConfigFileException,
     TriggerTypeException,
@@ -85,7 +86,10 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
         shipper_cache: dict[str, CompositeShipper] = {}
         for replay_record in lambda_event["Records"]:
             event = json_parser(replay_record["body"])
-            event["event_payload"] = gzip_base64_decoded(event["event_payload"])
+
+            if "messageAttributes" in replay_record and "payloadEncoding" in replay_record["messageAttributes"]:
+                if replay_record["messageAttributes"]["payloadEncoding"]["stringValue"] == GZIP_ENCODING:
+                    event["event_payload"] = gzip_base64_decoded(event["event_payload"])
 
             input_id = event["event_input_id"]
             output_destination = event["output_destination"]

--- a/handlers/aws/handler.py
+++ b/handlers/aws/handler.py
@@ -1,7 +1,6 @@
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
-import gzip
 import os
 from typing import Any, Callable, Optional
 
@@ -35,7 +34,7 @@ from .utils import (
     get_shipper_from_input,
     get_sqs_client,
     get_trigger_type_and_config_source,
-    try_base64_decode,
+    gzip_base64_decoded,
     wrap_try_except,
 )
 
@@ -86,12 +85,7 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
         shipper_cache: dict[str, CompositeShipper] = {}
         for replay_record in lambda_event["Records"]:
             event = json_parser(replay_record["body"])
-
-            decoded, ok = try_base64_decode(event["event_payload"])
-            if ok:
-                shared_logger.debug("processing base64 encoded and gzipped event")
-                event_str = gzip.decompress(decoded).decode("utf-8")
-                event["event_payload"] = json_parser(event_str)
+            event["event_payload"] = gzip_base64_decoded(event["event_payload"])
 
             input_id = event["event_input_id"]
             output_destination = event["output_destination"]

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -30,6 +30,7 @@ _available_triggers: dict[str, str] = {"aws:s3": "s3-sqs", "aws:sqs": "sqs", "aw
 CONFIG_FROM_PAYLOAD: str = "CONFIG_FROM_PAYLOAD"
 CONFIG_FROM_S3FILE: str = "CONFIG_FROM_S3FILE"
 INTEGRATION_SCOPE_GENERIC: str = "generic"
+PAYLOAD_ENCODING_KEY: str = "payloadEncoding"
 GZIP_ENCODING: str = "gzip"
 
 
@@ -467,7 +468,7 @@ class ReplayEventHandler:
             "event_input_id": self._event_input_id,
         }
 
-        message_attributes = {"payloadEncoding": {"StringValue": GZIP_ENCODING, "DataType": "String"}}
+        message_attributes = {PAYLOAD_ENCODING_KEY: {"StringValue": GZIP_ENCODING, "DataType": "String"}}
         sqs_client.send_message(
             QueueUrl=sqs_replay_queue, MessageBody=json_dumper(message_payload), MessageAttributes=message_attributes
         )

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -615,12 +615,13 @@ def expand_event_list_from_field_resolver(integration_scope: str, field_to_expan
     return field_to_expand_event_list_from
 
 
-def try_base64_decode(data: str) -> tuple[bytes, bool]:
+def gzip_base64_decoded(message: str) -> Any:
     try:
-        decoded = base64.b64decode(data, validate=True)
-        return decoded, True
+        decoded = base64.b64decode(message, validate=True)
+        return json_parser(gzip.decompress(decoded).decode("utf-8"))
     except Exception:
-        return bytes(), False
+        # if decoding fails, return the original
+        return message
 
 
 def gzip_base64_encoded(message: str) -> str:

--- a/tests/handlers/aws/test_integrations.py
+++ b/tests/handlers/aws/test_integrations.py
@@ -16,6 +16,7 @@ from botocore.client import BaseClient as BotoBaseClient
 from testcontainers.localstack import LocalStackContainer
 
 from handlers.aws.exceptions import ReplayHandlerException
+from handlers.aws.utils import try_base64_decode
 from main_aws import handler
 from share import get_hex_prefix, json_dumper, json_parser
 from tests.testcontainers.es import ElasticsearchContainer
@@ -3851,6 +3852,12 @@ class TestLambdaHandlerIntegration(TestCase):
         first_body: dict[str, Any] = json_parser(events["Records"][0]["body"])
         second_body: dict[str, Any] = json_parser(events["Records"][1]["body"])
 
+        decoded, _ = try_base64_decode(first_body["event_payload"])
+        first_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
+
+        decoded, _ = try_base64_decode(second_body["event_payload"])
+        second_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
+
         assert first_body["event_payload"]["message"] == fixtures[0].rstrip("\n")
         assert first_body["event_payload"]["log"]["offset"] == 0
         assert first_body["event_payload"]["log"]["file"]["path"] == sqs_queue_url_path
@@ -4028,6 +4035,12 @@ class TestLambdaHandlerIntegration(TestCase):
         first_body: dict[str, Any] = json_parser(events["Records"][0]["body"])
         second_body: dict[str, Any] = json_parser(events["Records"][1]["body"])
 
+        decoded, _ = try_base64_decode(first_body["event_payload"])
+        first_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
+
+        decoded, _ = try_base64_decode(second_body["event_payload"])
+        second_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
+
         assert first_body["event_payload"]["message"] == fixtures[0].rstrip("\n")
         assert first_body["event_payload"]["log"]["offset"] == 0
         assert first_body["event_payload"]["log"]["file"]["path"] == sqs_queue_url_path
@@ -4115,6 +4128,12 @@ class TestLambdaHandlerIntegration(TestCase):
 
         first_body: dict[str, Any] = json_parser(events["Records"][0]["body"])
         second_body: dict[str, Any] = json_parser(events["Records"][1]["body"])
+
+        decoded, _ = try_base64_decode(first_body["event_payload"])
+        first_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
+
+        decoded, _ = try_base64_decode(second_body["event_payload"])
+        second_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
 
         assert first_body["event_payload"]["message"] == fixtures[0].rstrip("\n")
         assert first_body["event_payload"]["log"]["offset"] == 0
@@ -4411,6 +4430,9 @@ class TestLambdaHandlerIntegration(TestCase):
 
         first_body: dict[str, Any] = json_parser(events["Records"][0]["body"])
 
+        decoded, _ = try_base64_decode(first_body["event_payload"])
+        first_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
+
         assert first_body["event_payload"]["message"] == fixtures[0].rstrip("\n")
         assert first_body["event_payload"]["log"]["offset"] == 0
         assert first_body["event_payload"]["log"]["file"]["path"] == sqs_queue_url_path
@@ -4523,6 +4545,9 @@ class TestLambdaHandlerIntegration(TestCase):
         assert len(events["Records"]) == 1
 
         first_body: dict[str, Any] = json_parser(events["Records"][0]["body"])
+
+        decoded, _ = try_base64_decode(first_body["event_payload"])
+        first_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
 
         assert first_body["event_payload"]["message"] == fixtures[0].rstrip("\n")
         assert first_body["event_payload"]["log"]["offset"] == 0

--- a/tests/handlers/aws/test_integrations.py
+++ b/tests/handlers/aws/test_integrations.py
@@ -16,7 +16,7 @@ from botocore.client import BaseClient as BotoBaseClient
 from testcontainers.localstack import LocalStackContainer
 
 from handlers.aws.exceptions import ReplayHandlerException
-from handlers.aws.utils import try_base64_decode
+from handlers.aws.utils import gzip_base64_decoded
 from main_aws import handler
 from share import get_hex_prefix, json_dumper, json_parser
 from tests.testcontainers.es import ElasticsearchContainer
@@ -3852,11 +3852,8 @@ class TestLambdaHandlerIntegration(TestCase):
         first_body: dict[str, Any] = json_parser(events["Records"][0]["body"])
         second_body: dict[str, Any] = json_parser(events["Records"][1]["body"])
 
-        decoded, _ = try_base64_decode(first_body["event_payload"])
-        first_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
-
-        decoded, _ = try_base64_decode(second_body["event_payload"])
-        second_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
+        first_body["event_payload"] = gzip_base64_decoded(first_body["event_payload"])
+        second_body["event_payload"] = gzip_base64_decoded(second_body["event_payload"])
 
         assert first_body["event_payload"]["message"] == fixtures[0].rstrip("\n")
         assert first_body["event_payload"]["log"]["offset"] == 0
@@ -4035,11 +4032,8 @@ class TestLambdaHandlerIntegration(TestCase):
         first_body: dict[str, Any] = json_parser(events["Records"][0]["body"])
         second_body: dict[str, Any] = json_parser(events["Records"][1]["body"])
 
-        decoded, _ = try_base64_decode(first_body["event_payload"])
-        first_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
-
-        decoded, _ = try_base64_decode(second_body["event_payload"])
-        second_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
+        first_body["event_payload"] = gzip_base64_decoded(first_body["event_payload"])
+        second_body["event_payload"] = gzip_base64_decoded(second_body["event_payload"])
 
         assert first_body["event_payload"]["message"] == fixtures[0].rstrip("\n")
         assert first_body["event_payload"]["log"]["offset"] == 0
@@ -4129,11 +4123,8 @@ class TestLambdaHandlerIntegration(TestCase):
         first_body: dict[str, Any] = json_parser(events["Records"][0]["body"])
         second_body: dict[str, Any] = json_parser(events["Records"][1]["body"])
 
-        decoded, _ = try_base64_decode(first_body["event_payload"])
-        first_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
-
-        decoded, _ = try_base64_decode(second_body["event_payload"])
-        second_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
+        first_body["event_payload"] = gzip_base64_decoded(first_body["event_payload"])
+        second_body["event_payload"] = gzip_base64_decoded(second_body["event_payload"])
 
         assert first_body["event_payload"]["message"] == fixtures[0].rstrip("\n")
         assert first_body["event_payload"]["log"]["offset"] == 0
@@ -4429,9 +4420,7 @@ class TestLambdaHandlerIntegration(TestCase):
         assert len(events["Records"]) == 1
 
         first_body: dict[str, Any] = json_parser(events["Records"][0]["body"])
-
-        decoded, _ = try_base64_decode(first_body["event_payload"])
-        first_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
+        first_body["event_payload"] = gzip_base64_decoded(first_body["event_payload"])
 
         assert first_body["event_payload"]["message"] == fixtures[0].rstrip("\n")
         assert first_body["event_payload"]["log"]["offset"] == 0
@@ -4545,9 +4534,7 @@ class TestLambdaHandlerIntegration(TestCase):
         assert len(events["Records"]) == 1
 
         first_body: dict[str, Any] = json_parser(events["Records"][0]["body"])
-
-        decoded, _ = try_base64_decode(first_body["event_payload"])
-        first_body["event_payload"] = json_parser(gzip.decompress(decoded).decode("utf-8"))
+        first_body["event_payload"] = gzip_base64_decoded(first_body["event_payload"])
 
         assert first_body["event_payload"]["message"] == fixtures[0].rstrip("\n")
         assert first_body["event_payload"]["log"]["offset"] == 0

--- a/tests/handlers/aws/utils.py
+++ b/tests/handlers/aws/utils.py
@@ -237,6 +237,14 @@ def _sqs_send_messages(client: BotoBaseClient, queue_url: str, message_body: str
     )
 
 
+def _sqs_send_messages_with_attribs(client: BotoBaseClient, queue_url: str, message_body: str, attribs: Any) -> None:
+    client.send_message(
+        QueueUrl=queue_url,
+        MessageBody=message_body,
+        MessageAttributes=attribs,
+    )
+
+
 def _sqs_get_messages(client: BotoBaseClient, queue_url: str, queue_arn: str = "") -> tuple[dict[str, Any], list[str]]:
     """
     A function to extract all messages from a SQS queue, specified by URL.


### PR DESCRIPTION
## What does this PR do?

AWS recently increased CloduWatch message size to 1MB [^1]. However, SQS message size is still capped at 256KB [^2].

This means, replay messages generated from CloudWatch input can cause SQS message limit (see screenshot below)

![image](https://github.com/user-attachments/assets/7de96871-6411-47fa-8db2-09988098648c)

This PR attempts to avoid this edge case by adding gzip compression to SQS message's event payload. While this will not 100% eliminate the limitation, this improvement allows to handle SQS max message size (1MB) if gzip compression ratio of that message reaches at least 4:1 (1MB : 250KB).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md` and updated `share/version.py`, if my change requires a new release.


## How to test this PR locally

- Build the lambda zip (`make package`)
- Deploy using the terraform helper
- Make a configuration error like invalid api key so that the event get pushed to SQS
- Retrieve and check the message to see the content to verify gzip compression

I have validated replying same message through Lambda to validate correct parsing of gzipped payloads.

## Screenshots

Compressed vs uncompressed message size comparison at SQS queue,

![image](https://github.com/user-attachments/assets/fd03ac44-d104-4fe9-bfc3-edf9cd2757ec)

[^1]: https://aws.amazon.com/about-aws/whats-new/2025/04/amazon-cloudwatch-logs-increases-log-event-size-1-mb
[^2]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
