### PR TITLE
[doc] Rebrand privatelink traffic filters to private connectivity

### DIFF
--- a/docs/reference/aws-deploy-elastic-serverless-forwarder.md
+++ b/docs/reference/aws-deploy-elastic-serverless-forwarder.md
@@ -312,9 +312,9 @@ Both parameters are required in order to attach the Elastic Serverless Forwarder
 
 If the Elastic Serverless Forwarder is attached to a VPC, you need to [create VPC endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html) for S3 and SQS, and for **every** service you define as an input for the forwarder. S3 and SQS VPC endpoints are always required for reading the `config.yaml` uploaded to S3 and managing the continuing queue and the replay queue, regardless of the [Inputs](/reference/index.md#aws-serverless-forwarder-inputs) used. If you use [Amazon CloudWatch Logs subscription filters](/reference/index.md#aws-serverless-forwarder-inputs-cloudwatch), you need to create a VPC endpoint for EC2, too.
 
-::::{note}
+:::{note}
 Refer to the [AWS PrivateLink private connectivity](docs-content://deploy-manage/security/private-connectivity-aws.md) documentation to find your VPC endpoint ID and the hostname to use in the `config.yml` in order to access your Elasticsearch cluster over PrivateLink.
-::::
+:::
 
 
 

--- a/docs/reference/aws-deploy-elastic-serverless-forwarder.md
+++ b/docs/reference/aws-deploy-elastic-serverless-forwarder.md
@@ -313,7 +313,7 @@ Both parameters are required in order to attach the Elastic Serverless Forwarder
 If the Elastic Serverless Forwarder is attached to a VPC, you need to [create VPC endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html) for S3 and SQS, and for **every** service you define as an input for the forwarder. S3 and SQS VPC endpoints are always required for reading the `config.yaml` uploaded to S3 and managing the continuing queue and the replay queue, regardless of the [Inputs](/reference/index.md#aws-serverless-forwarder-inputs) used. If you use [Amazon CloudWatch Logs subscription filters](/reference/index.md#aws-serverless-forwarder-inputs-cloudwatch), you need to create a VPC endpoint for EC2, too.
 
 ::::{note}
-Refer to the [AWS PrivateLink traffic filters](docs-content://deploy-manage/security/aws-privatelink-traffic-filters.md) documentation to find your VPC endpoint ID and the hostname to use in the `config.yml` in order to access your Elasticsearch cluster over PrivateLink.
+Refer to the [AWS PrivateLink private connectivity](docs-content://deploy-manage/security/private-connectivity-aws.md) documentation to find your VPC endpoint ID and the hostname to use in the `config.yml` in order to access your Elasticsearch cluster over PrivateLink.
 ::::
 
 


### PR DESCRIPTION
part of https://github.com/elastic/platform-docs-team/issues/682

prerequisites:
* https://github.com/elastic/docs-content/pull/1785/
* https://github.com/elastic/docs-content/pull/2047

I don't have permission to add labels to this PR

## What does this PR do?

Rebrands privatelink traffic filters to private connectivity based on a larger change to Elastic Cloud network security

## Why is it important?

Network security terminology and docs are changing, making the existing doc link invalid

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation

~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.md` and updated `share/version.py`, if my change requires a new release.~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] preview docs

## How to test this PR locally

link coming after preview CI runs

## Related issues

part of https://github.com/elastic/platform-docs-team/issues/682

prerequisites:
* https://github.com/elastic/docs-content/pull/1785/
* https://github.com/elastic/docs-content/pull/2047
