### PR TITLE
[Docs] Convert asciidoc lifecycle markers into Docs V3 syntax

### DIFF
--- a/docs/reference/aws-deploy-elastic-serverless-forwarder.md
+++ b/docs/reference/aws-deploy-elastic-serverless-forwarder.md
@@ -204,7 +204,7 @@ A list of outputs (i.e. forwarding targets) for the Elastic Serverless Forwarder
 The type of the forwarding target output. Currently only the following outputs are supported:
 
 * `elasticsearch`
-* [preview] `logstash`
+* {applies_to}`stack: preview` `logstash`
 
 Each type can only be used for a maximum of one output up to and including 1.14.0 version. If {{ls}} is chosen as an output, Elastic Serverless Forwarder expects the [`elastic_serverless_forwarder`](logstash-docs-md://lsr/plugins-inputs-elastic_serverless_forwarder.md) Logstash input to be installed, enabled, and properly configured. For more information about installing Logstash plugins, refer to the [Logstash documentation](logstash://reference/working-with-plugins.md#installing-plugins).
 

--- a/docs/reference/aws-deploy-elastic-serverless-forwarder.md
+++ b/docs/reference/aws-deploy-elastic-serverless-forwarder.md
@@ -204,7 +204,7 @@ A list of outputs (i.e. forwarding targets) for the Elastic Serverless Forwarder
 The type of the forwarding target output. Currently only the following outputs are supported:
 
 * `elasticsearch`
-* {applies_to}`stack: preview` `logstash`
+* {applies_to}`product: preview` `logstash`
 
 Each type can only be used for a maximum of one output up to and including 1.14.0 version. If {{ls}} is chosen as an output, Elastic Serverless Forwarder expects the [`elastic_serverless_forwarder`](logstash-docs-md://lsr/plugins-inputs-elastic_serverless_forwarder.md) Logstash input to be installed, enabled, and properly configured. For more information about installing Logstash plugins, refer to the [Logstash documentation](logstash://reference/working-with-plugins.md#installing-plugins).
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -18,7 +18,7 @@ Using Elastic Serverless Forwarder may result in additional charges. To learn ho
 
 ## Overview [aws-serverless-forwarder-overview]
 
-The Elastic Serverless Forwarder can forward AWS data to cloud-hosted, self-managed Elastic environments, or {applies_to}`stack: preview` {{ls}}. It supports the following inputs:
+The Elastic Serverless Forwarder can forward AWS data to cloud-hosted, self-managed Elastic environments, or {applies_to}`product: preview` {{ls}}. It supports the following inputs:
 
 * Amazon S3 (via SQS event notifications)
 * Amazon Kinesis Data Streams

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -18,7 +18,7 @@ Using Elastic Serverless Forwarder may result in additional charges. To learn ho
 
 ## Overview [aws-serverless-forwarder-overview]
 
-The Elastic Serverless Forwarder can forward AWS data to cloud-hosted, self-managed Elastic environments, or [preview]{{ls}}. It supports the following inputs:
+The Elastic Serverless Forwarder can forward AWS data to cloud-hosted, self-managed Elastic environments, or {applies_to}`stack: preview` {{ls}}. It supports the following inputs:
 
 * Amazon S3 (via SQS event notifications)
 * Amazon Kinesis Data Streams


### PR DESCRIPTION
Type of change: Docs - can't edit labels

## What does this PR do?

This PR converts some [preview] markers that were still following the asciidoc syntax into the syntax expected by the new markdown docs system.
@colleenmcginnis ~let me know if the 'stack' key makes sense here or if you have a better one in mind.~ Changed to "product: preview" to simply show a small preview badge

## Related issues

Rel: https://github.com/elastic/docs-content/issues/2951

