### PR TITLE
security: upgrade pytest to 9.0.3 (CVE-2025-71176) and add dev bootstrap docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Elastic Serverless Forwarder (ESF) is an AWS Lambda function that ships logs from AWS services (S3 via SQS, Kinesis Data Streams, CloudWatch Logs, SQS) to Elastic Stack (Elasticsearch or Logstash).
+
+## Bootstrap
+
+```bash
+python -m venv venv
+. venv/bin/activate
+pip install -r requirements.txt -r requirements-lint.txt -r requirements-tests.txt
+```
+
+Or use the Makefile: `make all-requirements` (skips venv creation).
+
+## Common Commands
+
+### Testing
+- `make test` — run all tests except benchmarks
+- `make unit-test` — run unit tests only
+- `make integration-test` — run integration tests only
+- `make benchmark` — run benchmarks
+- `make coverage` — run tests with coverage
+- Run a single test: `python -m pytest tests/path/to/test_file.py::TestClass::test_method -m unit`
+
+### Linting & Formatting
+- `make lint` — run all linters (black, flake8, isort, mypy)
+- `make black` / `make flake8` / `make isort` / `make mypy` — run individually
+- Auto-fix formatting: `./tests/scripts/black.sh fix` and `./tests/scripts/isort.sh fix`
+- Fix license headers: `./tests/scripts/license_headers_check.sh fix`
+
+### Packaging
+- `make package` — create Lambda deployment ZIP (`local_esf.zip`)
+
+All test/lint commands have `docker-` prefixed equivalents (e.g., `make docker-test`) matching CI.
+
+## Architecture
+
+**Entry point:** `main_aws.py` → `handlers/aws/handler.py:lambda_handler()`
+
+The handler detects the trigger type and routes to the appropriate trigger module. Each trigger reads events from a **storage** (input) and sends them through a **shipper** (output).
+
+Four domain packages:
+
+- **`handlers/`** — Cloud-specific Lambda logic. Trigger modules: `cloudwatch_logs_trigger.py`, `s3_sqs_trigger.py`, `sqs_trigger.py`, `kinesis_trigger.py`, `replay_trigger.py`. Config loading and trigger detection live in `utils.py`.
+- **`storage/`** — Input sources (S3, direct payload). Protocol-based with `StorageFactory`.
+- **`shippers/`** — Output destinations (Elasticsearch bulk API, Logstash TCP). Protocol-based with `ShipperFactory`. `CompositeShipper` handles batching and multi-output.
+- **`share/`** — Shared utilities: config parsing/validation (`config.py`), JSON multi-backend support (`json.py` — orjson, ujson, simplejson, rapidjson, cysimdjson), logging (`logger.py`), multiline processing, include/exclude filtering, Secrets Manager integration.
+
+## Code Style
+
+- **Black** with line-length=120, target py39+
+- **isort** for import ordering
+- **flake8** with max-line-length=120
+- **mypy** strict mode, Python 3.12
+- All source files require Elastic License 2.0 headers
+- Test coverage target: 100% for code outside `handlers/`
+
+## Test Structure
+
+Tests mirror the source tree under `tests/`. Markers: `unit`, `integration`, `benchmark`. Test containers for Elasticsearch and Logstash are in `tests/testcontainers/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,16 @@ The process for contributing to any of the Elastic repositories is similar.
 
 1. Please make sure you have signed the [Contributor License Agreement](http://www.elastic.co/contributor-agreement/). We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
 
-2. Install the required dependencies. We have three different dependencies sets respectively for the app, linting and tests. You can install them all together or separately, either in a virtualenv or not, according to your preferences. The `make` targets provided are the following:
+2. Set up a virtual environment and install the required dependencies. We have three different dependencies sets respectively for the app, linting and tests. You can install them all together or separately according to your preferences.
+
+   First, create and activate a virtual environment:
+   ```bash
+   python -m venv venv
+   . venv/bin/activate
+   pip install -r requirements.txt -r requirements-lint.txt -r requirements-tests.txt
+   ```
+
+   Alternatively, you can use the `make` targets (these skip venv creation):
    * `all-requirements`     Install all requirements on the host
    * `requirements`         Install app requirements on the host
    * `requirements-lint`    Install all linting requirements on the host

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,5 @@
 mock==5.2.0
-pytest==8.4.2
+pytest==9.0.3
 pytest-cov==6.1.1
 pytest-benchmark==5.1.0
 coverage==7.9.1


### PR DESCRIPTION
## Summary
- Upgrade pytest from 8.4.2 to 9.0.3 to fix [CVE-2025-71176](https://nvd.nist.gov/vuln/detail/CVE-2025-71176) (insecure `/tmp/pytest-of-{user}` directory handling on UNIX — privilege escalation / DoS)
- Add `CLAUDE.md` with project bootstrap commands, common dev commands, and architecture overview
- Update `CONTRIBUTING.md` with virtualenv setup instructions before the existing dependency installation steps

## Test plan
- [x] Verify `pip install -r requirements-tests.txt` installs pytest 9.0.3
- [x] Verify `make test` passes with the upgraded pytest
- [x] Verify CLAUDE.md bootstrap instructions work from a clean checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)