### PR TITLE
Add AWS-compatible log level field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage
 .cache
 /testdb.sql
 venv
+.venv
 benchmarks/result*
 coverage.xml
 tests/elastic-serverless-forwarder-junit.xml

--- a/share/logger.py
+++ b/share/logger.py
@@ -4,9 +4,32 @@
 
 import logging
 import os
+from typing import Any
 
 import ecs_logging
 from elasticapm.handlers.logging import LoggingFilter
+
+# AWS CloudWatch Log Level Filtering requires a root-level "level" field.
+# Python's WARNING and CRITICAL don't match AWS's expected values.
+_AWS_LEVEL_MAP = {
+    "WARNING": "WARN",
+    "CRITICAL": "FATAL",
+}
+
+
+class AWSCompatibleFormatter(ecs_logging.StdlibFormatter):
+    """ECS formatter that also emits a root-level "level" field.
+
+    AWS CloudWatch Logs Log Level Filtering requires a top-level "level" field
+    in JSON-structured log output. ECS emits severity as the flat dotted key
+    "log.level", which AWS does not recognise for filtering purposes.
+    """
+
+    def format_to_ecs(self, record: logging.LogRecord) -> dict[str, Any]:
+        result = super().format_to_ecs(record)
+        result["level"] = _AWS_LEVEL_MAP.get(record.levelname, record.levelname)
+        return result
+
 
 log_level = logging.getLevelName(os.getenv("LOG_LEVEL", "INFO").upper())
 
@@ -17,7 +40,7 @@ logger.propagate = False
 
 # Add an ECS formatter to the Handler
 handler = logging.StreamHandler()
-handler.setFormatter(ecs_logging.StdlibFormatter())
+handler.setFormatter(AWSCompatibleFormatter())
 
 # Add an APM log correlation
 handler.addFilter(LoggingFilter())  # type: ignore

--- a/tests/share/test_logger.py
+++ b/tests/share/test_logger.py
@@ -1,0 +1,56 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+import io
+import json
+import logging
+from typing import Any, cast
+from unittest import TestCase
+
+import pytest
+
+from share.logger import AWSCompatibleFormatter
+
+
+def _formatted(level: int, msg: str = "test") -> dict[str, Any]:
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(AWSCompatibleFormatter())
+    log = logging.getLogger(f"test.{level}")
+    log.setLevel(logging.DEBUG)
+    log.propagate = False
+    log.handlers = [handler]
+    log.log(level, msg)
+    return cast(dict[str, Any], json.loads(stream.getvalue().strip()))
+
+
+@pytest.mark.unit
+class TestAWSCompatibleFormatter(TestCase):
+    def test_level_field_is_root_level(self) -> None:
+        record = _formatted(logging.INFO)
+        self.assertIn("level", record)
+
+    def test_ecs_log_level_preserved(self) -> None:
+        record = _formatted(logging.INFO)
+        self.assertEqual(record["log.level"], "info")
+
+    def test_debug_mapping(self) -> None:
+        self.assertEqual(_formatted(logging.DEBUG)["level"], "DEBUG")
+
+    def test_info_mapping(self) -> None:
+        self.assertEqual(_formatted(logging.INFO)["level"], "INFO")
+
+    def test_warning_maps_to_warn(self) -> None:
+        self.assertEqual(_formatted(logging.WARNING)["level"], "WARN")
+
+    def test_error_mapping(self) -> None:
+        self.assertEqual(_formatted(logging.ERROR)["level"], "ERROR")
+
+    def test_critical_maps_to_fatal(self) -> None:
+        self.assertEqual(_formatted(logging.CRITICAL)["level"], "FATAL")
+
+    def test_level_and_log_level_are_independent(self) -> None:
+        record = _formatted(logging.WARNING)
+        self.assertEqual(record["level"], "WARN")
+        self.assertEqual(record["log.level"], "warning")


### PR DESCRIPTION
## Summary

AWS Lambda application log-level filtering expects JSON logs to contain a root-level `level` field. ESF currently emits ECS-formatted logs with severity in the dotted `log.level` field, which Lambda does not use for native filtering.

This change extends the ECS formatter to:
- preserve the existing ECS `log.level` field
- add the corresponding root-level `level` field
- translate Python `WARNING` to AWS `WARN` and `CRITICAL` to AWS `FATAL`
- retain the ECS formatter's compact serialization path

It also adds focused unit coverage for all standard Python log levels.

## Level mapping

See [AWS Lambda log-level filtering](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-log-level.html) for the supported application log levels.

| ECS `log.level` | AWS `level` |
|---|---|
| `debug` | `DEBUG` |
| `info` | `INFO` |
| `warning` | `WARN` |
| `error` | `ERROR` |
| `critical` | `FATAL` |

## Test plan

- [x] `pytest tests/share/test_logger.py -m unit`
- [x] `mypy share/logger.py tests/share/test_logger.py`
- [x] Black, flake8, and isort checks for changed Python files
- [x] Full CI suite

## Screenshot

Quick test on AWS.

<img width="2842" height="1860" alt="CleanShot 2026-07-21 at 20 31 19@2x" src="https://github.com/user-attachments/assets/fba1a26d-f818-43a1-bf99-c77695bbea58" />

***

Made with [Cursor](https://cursor.com)