### PR TITLE
Release new version v1.21.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.21.6 - 2026/07/21
+#### Features
+* Add AWS-compatible log level field [1054](https://github.com/elastic/elastic-serverless-forwarder/pull/1054)
+
 ### v1.21.5 - 2026/06/30
 #### Security
 * Bump ujson to 5.13.0 to address CVE-2026-54911 [1050](https://github.com/elastic/elastic-serverless-forwarder/pull/1050)

--- a/docs/reference/aws-deploy-elastic-serverless-forwarder.md
+++ b/docs/reference/aws-deploy-elastic-serverless-forwarder.md
@@ -569,7 +569,7 @@ continuing-queue:
 
 A bash script for publishing the Elastic Serverless Forwarder directly to your AWS account is available from the [Elastic Serverless Forwarder repository](https://github.com/elastic/elastic-serverless-forwarder).
 
-Download the [`publish_lambda.sh` script](https://raw.githubusercontent.com/elastic/elastic-serverless-forwarder/lambda-v1.21.5/publish_lambda.sh) and follow the instructions below.
+Download the [`publish_lambda.sh` script](https://raw.githubusercontent.com/elastic/elastic-serverless-forwarder/lambda-v1.21.6/publish_lambda.sh) and follow the instructions below.
 
 
 #### Script arguments [_script_arguments]
@@ -607,7 +607,7 @@ $ pip3 install awscli aws-sam-cli ruamel.yaml
 Assuming `publish-config.yaml` in saved in the same directory you intend to run `publish_lambda.sh` from, here’s an example:
 
 ```bash
-$ ./publish_lambda.sh publish-config.yaml forwarder-lambda lambda-v1.21.5 s3-lambda-artifact-bucket-name eu-central-1
+$ ./publish_lambda.sh publish-config.yaml forwarder-lambda lambda-v1.21.6 s3-lambda-artifact-bucket-name eu-central-1
 ```
 
 
@@ -616,11 +616,11 @@ $ ./publish_lambda.sh publish-config.yaml forwarder-lambda lambda-v1.21.5 s3-lam
 You can update the version of a published Elastic Serverless Forwarder without changing its configuration by running the publishing script again and passing a **new** [`forwarder-tag`](https://github.com/elastic/elastic-serverless-forwarder/tags):
 
 ```bash
-$ ./publish_lambda.sh publish-config.yaml forwarder-lambda lambda-v1.21.5 s3-lambda-artifact-bucket-name eu-central-1
+$ ./publish_lambda.sh publish-config.yaml forwarder-lambda lambda-v1.21.6 s3-lambda-artifact-bucket-name eu-central-1
 ```
 
 ::::{note}
-The above examples show the forwarder being updated from `lambda-v1.19.0` to `lambda-v1.21.5`.
+The above examples show the forwarder being updated from `lambda-v1.19.0` to `lambda-v1.21.6`.
 ::::
 
 
@@ -630,11 +630,11 @@ The above examples show the forwarder being updated from `lambda-v1.19.0` to `la
 If you want to change the configuration of a published Elastic Serverless Forwarder without changing its version, you can update the `publish-config.yaml` and run the script again using the **same** `forwarder-tag`:
 
 ```bash
-$ ./publish_lambda.sh publish-config.yaml forwarder-lambda lambda-v1.21.5 s3-lambda-artifact-bucket-name eu-central-1
+$ ./publish_lambda.sh publish-config.yaml forwarder-lambda lambda-v1.21.6 s3-lambda-artifact-bucket-name eu-central-1
 ```
 
 ::::{note}
-The above example shows an existing `lambda-v1.21.5` configuration being updated without changing version.
+The above example shows an existing `lambda-v1.21.6` configuration being updated without changing version.
 ::::
 
 
@@ -644,9 +644,9 @@ The above example shows an existing `lambda-v1.21.5` configuration being updated
 If you want to use the publish script for deploying the forwarder with different configurations, create two different `publish-config.yaml` files with unique names and run the publishing script twice, with correct references to the `config-path` and `lambda-name`:
 
 ```bash
-$ ./publish_lambda.sh publish-config-for-first-lambda.yaml first-lambda lambda-v1.21.5 s3-lambda-artifact-bucket-name eu-central-1
+$ ./publish_lambda.sh publish-config-for-first-lambda.yaml first-lambda lambda-v1.21.6 s3-lambda-artifact-bucket-name eu-central-1
 
-$ ./publish_lambda.sh publish-config-for-second-lambda.yaml second-lambda lambda-v1.21.5 ss3-lambda-artifact-bucket-name eu-central-1
+$ ./publish_lambda.sh publish-config-for-second-lambda.yaml second-lambda lambda-v1.21.6 ss3-lambda-artifact-bucket-name eu-central-1
 ```
 
 ::::{note}

--- a/share/version.py
+++ b/share/version.py
@@ -2,4 +2,4 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-version = "1.21.5"
+version = "1.21.6"


### PR DESCRIPTION
## What does this PR do?

Release version v1.21.6 with a new feature adding AWS-compatible log level support.

## Why is it important?

AWS Lambda's native log-level filtering requires JSON logs to contain a root-level `level` field. ESF previously only emitted the ECS `log.level` field, which Lambda does not use for filtering. This release ships the fix so users can filter ESF logs directly from the Lambda console.

## Changes since v1.21.5

#### Features
* Add AWS-compatible log level field [#1054](https://github.com/elastic/elastic-serverless-forwarder/pull/1054)