### PR TITLE
feat: support KPL aggregated records on kinesis data stream inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.21.7 - 2026/08/19
+##### Features
+* Support KPL aggregated records on kinesis data stream inputs [1057](https://github.com/elastic/elastic-serverless-forwarder/pull/1057)
+
 ### v1.21.6 - 2026/07/21
 #### Features
 * Add AWS-compatible log level field [1054](https://github.com/elastic/elastic-serverless-forwarder/pull/1054)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -69,6 +69,8 @@ The forwarder can ingest logs contained in the payload of a Kinesis Data Stream 
 
 You can set up separate Kinesis Data Streams for each type of log. The `es_datastream_name` parameter in the config file is mandatory. If this value is set to an {{es}} data stream, the type of log must be correctly defined with configuration parameters. A single configuration file can have many input sections, pointing to different data streams that match specific log types.
 
+Records written with aggregation enabled, either by the Kinesis Producer Library or by a producer using the same aggregated record format, such as the `kinesis` output of `aws-for-fluent-bit` with `aggregation true`, carry more than one user record each. The forwarder expands those records and sends every user record it finds as its own event. Records written without aggregation are ingested unchanged, and no configuration is required in either case.
+
 
 ### Amazon CloudWatch Logs subscription filters [aws-serverless-forwarder-inputs-cloudwatch]
 

--- a/handlers/aws/handler.py
+++ b/handlers/aws/handler.py
@@ -15,6 +15,7 @@ from .cloudwatch_logs_trigger import (
     _handle_cloudwatch_logs_event,
     _handle_cloudwatch_logs_move,
 )
+from .kinesis_deaggregation import deaggregate_kinesis_records
 from .kinesis_trigger import _handle_kinesis_move, _handle_kinesis_record
 from .replay_trigger import ReplayedEventReplayHandler, get_shipper_for_replay_event
 from .s3_sqs_trigger import _handle_s3_sqs_event, _handle_s3_sqs_move
@@ -258,7 +259,16 @@ def lambda_handler(lambda_event: dict[str, Any], lambda_context: context_.Contex
         )
 
     if trigger_type == "kinesis-data-stream":
-        shared_logger.info("trigger", extra={"size": len(lambda_event["Records"])})
+        # a record sent with aggregation enabled carries more than one user record. Expanding them
+        # before anything else lets the rest of the flow, the continuing queue included, work on a
+        # single user record at a time, as every user record is shaped like a record lambda delivers.
+        kinesis_records_n = len(lambda_event["Records"])
+        lambda_event["Records"] = deaggregate_kinesis_records(lambda_event["Records"])
+
+        shared_logger.info(
+            "trigger",
+            extra={"size": len(lambda_event["Records"]), "kinesis_records": kinesis_records_n},
+        )
 
         input_id = lambda_event["Records"][0]["eventSourceARN"]
         event_input = config.get_input_by_id(input_id)

--- a/handlers/aws/kinesis_deaggregation.py
+++ b/handlers/aws/kinesis_deaggregation.py
@@ -1,0 +1,225 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+"""
+Support for the KPL aggregated record format on kinesis data stream inputs.
+
+A producer with aggregation enabled packs many user records into a single kinesis record:
+
+    [4 bytes magic 0xF3 0x89 0x9A 0xC2][protobuf AggregatedRecord][16 bytes MD5 of the protobuf]
+
+Recovering the user records needs four fields of that schema, which has not changed since the
+format was introduced, so the protobuf message is read here rather than by adding a protobuf
+runtime to the lambda package. The reader is checked in the tests against aggregated records
+built by the reference implementation, awslabs/kinesis-aggregation.
+"""
+
+import base64
+import hashlib
+from typing import Any, Iterator, Optional, Union
+
+from share import shared_logger
+
+_KPL_MAGIC = b"\xf3\x89\x9a\xc2"
+_DIGEST_LENGTH = 16
+
+# protobuf wire types
+_WIRE_VARINT = 0
+_WIRE_64_BIT = 1
+_WIRE_LENGTH_DELIMITED = 2
+_WIRE_32_BIT = 5
+
+# fields of AggregatedRecord: the explicit hash key table, field 2, is not needed
+_FIELD_PARTITION_KEY_TABLE = 1
+_FIELD_RECORDS = 3
+
+# fields of AggregatedRecord.Record: the tags, field 4, are not needed
+_FIELD_PARTITION_KEY_INDEX = 1
+_FIELD_DATA = 3
+
+
+def deaggregate_kinesis_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Expands every KPL aggregated record in the given kinesis records into the user records it
+    carries.
+
+    A record is recognised as aggregated by the KPL magic header and by the digest of its
+    payload, so records that were sent without aggregation are returned untouched.
+
+    The returned user records are shaped like the records lambda delivers, each with its own
+    partition key and with the sub sequence number it has within its aggregated record.
+    """
+    deaggregated: list[dict[str, Any]] = []
+    for record in records:
+        message = _aggregated_message(record["kinesis"]["data"])
+        if message is None:
+            deaggregated.append(record)
+            continue
+
+        try:
+            user_records = _user_records(record, message)
+        except ValueError as e:
+            # the digest matched, so this is an aggregated record we could not read at all.
+            # Forward it as it was received: the output gets the frame as opaque text rather than
+            # the lines it holds, which at least keeps its bytes together with the error below.
+            shared_logger.error(
+                "cannot deaggregate kinesis record, forwarding it as it was received",
+                extra={"sequence_number": record["kinesis"]["sequenceNumber"], "reason": str(e)},
+            )
+
+            user_records = [record]
+
+        deaggregated += user_records
+
+    return deaggregated
+
+
+def _aggregated_message(data: Union[str, bytes]) -> Optional[bytes]:
+    """
+    Returns the protobuf message of an aggregated record, or None if the payload does not hold
+    one. The digest is checked as well as the magic header: it is what separates an aggregated
+    record from a payload that merely begins with the same four bytes.
+    """
+    try:
+        payload = base64.b64decode(data, validate=True)
+    except ValueError:
+        # both the invalid character error of base64 and its non ascii input error are ValueError
+        return None
+
+    if not payload.startswith(_KPL_MAGIC) or len(payload) <= len(_KPL_MAGIC) + _DIGEST_LENGTH:
+        return None
+
+    message = payload[len(_KPL_MAGIC) : -_DIGEST_LENGTH]
+    if hashlib.md5(message, usedforsecurity=False).digest() != payload[-_DIGEST_LENGTH:]:
+        return None
+
+    return message
+
+
+def _user_records(record: dict[str, Any], message: bytes) -> list[dict[str, Any]]:
+    """
+    Builds a kinesis record for every user record of the given aggregated record message.
+
+    A user record that cannot be resolved is logged and left out, so that the others are still
+    forwarded. ValueError is raised only when the message carries no user record at all, or when
+    none of them could be read, as there is nothing left to forward in that case.
+    """
+    partition_keys: list[str] = []
+    record_messages: list[bytes] = []
+
+    # the fields are collected before any of them is resolved, so that a partition key index is
+    # looked up in the complete table whatever order the producer serialised the fields in
+    for field_number, value in _fields(message):
+        if field_number == _FIELD_PARTITION_KEY_TABLE and isinstance(value, bytes):
+            partition_keys.append(value.decode("utf-8"))
+        elif field_number == _FIELD_RECORDS and isinstance(value, bytes):
+            record_messages.append(value)
+
+    if not record_messages:
+        raise ValueError("no user record in the aggregated record")
+
+    user_records: list[dict[str, Any]] = []
+    unreadable: list[str] = []
+    for subsequence_number, record_message in enumerate(record_messages):
+        try:
+            user_records.append(_user_record(record, record_message, partition_keys, subsequence_number))
+        except ValueError as e:
+            unreadable.append(str(e))
+
+    # reported once for the whole record rather than once per user record: a producer writing
+    # indices it never filled in would otherwise log every user record of every record of a batch
+    if unreadable:
+        shared_logger.error(
+            "cannot read some user records of a kinesis record, skipping them",
+            extra={
+                "sequence_number": record["kinesis"]["sequenceNumber"],
+                "skipped": len(unreadable),
+                "user_records": len(record_messages),
+                "reason": unreadable[0],
+            },
+        )
+
+    if not user_records:
+        raise ValueError(f"none of the {len(record_messages)} user records could be read")
+
+    return user_records
+
+
+def _user_record(
+    record: dict[str, Any], message: bytes, partition_keys: list[str], subsequence_number: int
+) -> dict[str, Any]:
+    """Builds a single user record, shaped like the records lambda delivers."""
+    partition_key_index = 0
+    data = b""
+
+    for field_number, value in _fields(message):
+        if field_number == _FIELD_PARTITION_KEY_INDEX and isinstance(value, int):
+            partition_key_index = value
+        elif field_number == _FIELD_DATA and isinstance(value, bytes):
+            data = value
+
+    if partition_key_index >= len(partition_keys):
+        raise ValueError(f"partition key {partition_key_index} is not in the partition key table")
+
+    user_record: dict[str, Any] = {key: value for key, value in record.items() if key != "kinesis"}
+
+    # everything the user record shares with the record it was aggregated in is kept, including
+    # the sequence number and the arrival timestamp, and the rest is its own
+    user_record["kinesis"] = {
+        **record["kinesis"],
+        "partitionKey": partition_keys[partition_key_index],
+        "subSequenceNumber": subsequence_number,
+        "data": base64.b64encode(data).decode("utf-8"),
+    }
+
+    return user_record
+
+
+def _fields(message: bytes) -> Iterator[tuple[int, Union[int, bytes]]]:
+    """
+    Yields the field number and the value of every field of a protobuf message: an int for a
+    varint field, the raw bytes for a length delimited one. Fixed width fields are skipped, as
+    the schema of an aggregated record has none.
+    """
+    position = 0
+    while position < len(message):
+        tag, position = _varint(message, position)
+        field_number, wire_type = tag >> 3, tag & 0x07
+
+        if wire_type == _WIRE_VARINT:
+            value, position = _varint(message, position)
+            yield field_number, value
+        elif wire_type == _WIRE_LENGTH_DELIMITED:
+            length, position = _varint(message, position)
+            end = position + length
+            if end > len(message):
+                raise ValueError(f"field {field_number} does not fit in the message")
+
+            yield field_number, message[position:end]
+            position = end
+        elif wire_type in (_WIRE_64_BIT, _WIRE_32_BIT):
+            position += 8 if wire_type == _WIRE_64_BIT else 4
+            if position > len(message):
+                raise ValueError(f"field {field_number} does not fit in the message")
+        else:
+            raise ValueError(f"field {field_number} has unsupported wire type {wire_type}")
+
+
+def _varint(message: bytes, position: int) -> tuple[int, int]:
+    """Reads a base 128 varint, returning its value and the position right after it."""
+    value = 0
+    shift = 0
+    while True:
+        if position >= len(message):
+            raise ValueError("varint does not fit in the message")
+
+        byte = message[position]
+        position += 1
+        value |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return value, position
+
+        shift += 7
+        if shift > 63:
+            raise ValueError("varint is longer than 64 bits")

--- a/handlers/aws/kinesis_trigger.py
+++ b/handlers/aws/kinesis_trigger.py
@@ -53,6 +53,14 @@ def _handle_kinesis_move(
         },
     }
 
+    # forwarded so that the events of a user record keep the same id once the record is processed from
+    # the continuing queue: only the user records of an aggregated record carry it
+    if "subSequenceNumber" in kinesis_record["kinesis"]:
+        message_attributes["originalSubsequenceNumber"] = {
+            "StringValue": str(kinesis_record["kinesis"]["subSequenceNumber"]),
+            "DataType": "Number",
+        }
+
     if last_ending_offset is not None:
         message_attributes["originalLastEndingOffset"] = {"StringValue": str(last_ending_offset), "DataType": "Number"}
 
@@ -155,5 +163,12 @@ def _handle_kinesis_record(
                     ),
                 },
             }
+
+            # only the user records of an aggregated record carry a sub sequence number: leaving it out
+            # otherwise keeps the event, and the id generated from it, as it was before deaggregation
+            if "subSequenceNumber" in kinesis_record["kinesis"]:
+                es_event["fields"]["aws"]["kinesis"]["subsequence_number"] = kinesis_record["kinesis"][
+                    "subSequenceNumber"
+                ]
 
             yield es_event, ending_offset, event_expanded_offset, kinesis_record_n

--- a/handlers/aws/sqs_trigger.py
+++ b/handlers/aws/sqs_trigger.py
@@ -221,6 +221,13 @@ def _handle_sqs_event(
                     "sequence_number": sequence_number,
                 }
             }
+            # present only when the record this message came from was a user record of an aggregated
+            # record: it keeps the id of the event the same as the one generated before continuing
+            if "originalSubsequenceNumber" in payload:
+                es_event["fields"]["aws"]["kinesis"]["subsequence_number"] = int(
+                    payload["originalSubsequenceNumber"]["stringValue"]
+                )
+
             es_event["meta"]["approximate_arrival_timestamp"] = approximate_arrival_timestamp
 
         yield es_event, ending_offset, event_expanded_offset

--- a/handlers/aws/utils.py
+++ b/handlers/aws/utils.py
@@ -616,7 +616,16 @@ def kinesis_record_id(event_payload: dict[str, Any]) -> str:
     sequence_number: str = str(event_payload["fields"]["aws"]["kinesis"]["sequence_number"])
     approximate_arrival_timestamp: int = int(event_payload["meta"]["approximate_arrival_timestamp"])
 
-    src: str = "-".join([stream_type, stream_name, partition_key, sequence_number])
+    src_components: list[str] = [stream_type, stream_name, partition_key, sequence_number]
+
+    # the user records of an aggregated record share the partition key and the sequence number of the
+    # record they were aggregated in, and each of them starts at offset zero: the sub sequence number
+    # is what keeps their ids unique. It is absent for records that were not aggregated, whose ids are
+    # therefore left untouched.
+    if "subsequence_number" in event_payload["fields"]["aws"]["kinesis"]:
+        src_components.append(str(event_payload["fields"]["aws"]["kinesis"]["subsequence_number"]))
+
+    src: str = "-".join(src_components)
     hex_src = get_hex_prefix(src)
 
     return "-".join([str(approximate_arrival_timestamp), hex_src, f"{offset:012d}"])

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,6 +11,9 @@ exclude = venv/.*
 [mypy-elasticapm.*]
 ignore_missing_imports = True
 
+[mypy-aws_kinesis_agg.*]
+ignore_missing_imports = True
+
 [mypy-boto3.*]
 ignore_missing_imports = True
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -12,3 +12,9 @@ responses==0.25.7
 types-requests<2.32.4.20260108
 testcontainers==3.7.1
 pyOpenSSL==26.0.0
+# Reference implementation of the KPL aggregated record format. It builds the aggregated records
+# the deaggregation tests run against, so the format we accept is not defined by the same code
+# that reads it. `six` is pinned too because aws-kinesis-agg imports it without declaring it.
+aws-kinesis-agg==1.2.3
+protobuf==7.35.1
+six==1.17.0

--- a/share/version.py
+++ b/share/version.py
@@ -2,4 +2,4 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 
-version = "1.21.6"
+version = "1.21.7"

--- a/tests/handlers/aws/test_integrations.py
+++ b/tests/handlers/aws/test_integrations.py
@@ -28,6 +28,7 @@ from .utils import (
     ContextMock,
     _create_secrets,
     _kinesis_create_stream,
+    _kinesis_put_aggregated_record,
     _kinesis_put_records,
     _kinesis_retrieve_event_from_kinesis_stream,
     _load_file_fixture,
@@ -2888,6 +2889,78 @@ class TestLambdaHandlerIntegration(TestCase):
 
         for message in replayed_messages:
             assert kinesis_stream_arn == message["messageAttributes"]["originalEventSourceARN"]["stringValue"]
+
+    def test_kinesis_data_stream_aggregated_record(self) -> None:
+        # only elasticsearch is used as output: it is where the _id of an event decides whether the
+        # event is indexed or dropped as a duplicate
+        assert isinstance(self.elasticsearch, ElasticsearchContainer)
+        assert isinstance(self.localstack, LocalStackContainer)
+
+        # every user record of an aggregated record carries the partition key and the sequence number of
+        # the record it was aggregated in, and each of them starts at offset zero: without the sub
+        # sequence number telling them apart they would all be given the same _id and only one of them
+        # would make it into the datastream
+        fixtures = [json_dumper({"message": f"line{n}"}) for n in range(10)]
+
+        kinesis_stream_name = _time_based_id(suffix="source-kinesis")
+        kinesis_stream = _kinesis_create_stream(self.kinesis_client, kinesis_stream_name)
+        kinesis_stream_arn = kinesis_stream["StreamDescription"]["StreamARN"]
+
+        _kinesis_put_aggregated_record(self.kinesis_client, kinesis_stream_name, fixtures)
+
+        config_yaml: str = f"""
+            inputs:
+              - type: "kinesis-data-stream"
+                id: "{kinesis_stream_arn}"
+                tags: {self.default_tags}
+                outputs:
+                  - type: "elasticsearch"
+                    args:
+                      elasticsearch_url: "{self.elasticsearch.get_url()}"
+                      ssl_assert_fingerprint: {self.elasticsearch.ssl_assert_fingerprint}
+                      username: "{self.secret_arn}:username"
+                      password: "{self.secret_arn}:password"
+        """
+
+        config_file_path = "config.yaml"
+        config_bucket_name = _time_based_id(suffix="config-bucket")
+        _s3_upload_content_to_bucket(
+            client=self.s3_client,
+            content=config_yaml.encode("utf-8"),
+            content_type="text/plain",
+            bucket_name=config_bucket_name,
+            key=config_file_path,
+        )
+
+        os.environ["S3_CONFIG_FILE"] = f"s3://{config_bucket_name}/{config_file_path}"
+
+        events_kinesis, _ = _kinesis_retrieve_event_from_kinesis_stream(
+            self.kinesis_client, kinesis_stream_name, kinesis_stream_arn
+        )
+
+        # the aggregated record reaches the lambda as a single kinesis record
+        assert len(events_kinesis["Records"]) == 1
+
+        ctx = ContextMock(remaining_time_in_millis=_OVER_COMPLETION_GRACE_PERIOD_2m)
+        first_call = handler(events_kinesis, ctx)  # type: ignore
+
+        assert first_call == "completed"
+
+        self.elasticsearch.refresh(index="logs-generic-default")
+        assert self.elasticsearch.count(index="logs-generic-default")["count"] == len(fixtures)
+
+        res = self.elasticsearch.search(index="logs-generic-default", size=len(fixtures), sort="_seq_no")
+
+        assert sorted(hit["_source"]["message"] for hit in res["hits"]["hits"]) == sorted(fixtures)
+
+        # every user record keeps the sequence number of the aggregated record and is told apart by its
+        # own sub sequence number
+        assert {hit["_source"]["aws"]["kinesis"]["sequence_number"] for hit in res["hits"]["hits"]} == {
+            events_kinesis["Records"][0]["kinesis"]["sequenceNumber"]
+        }
+        assert sorted(hit["_source"]["aws"]["kinesis"]["subsequence_number"] for hit in res["hits"]["hits"]) == list(
+            range(len(fixtures))
+        )
 
     def test_kinesis_data_stream_last_ending_offset_reset(self) -> None:
         assert isinstance(self.logstash, LogstashContainer)

--- a/tests/handlers/aws/test_kinesis_deaggregation.py
+++ b/tests/handlers/aws/test_kinesis_deaggregation.py
@@ -1,0 +1,353 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+import base64
+import gzip
+import hashlib
+import json
+from typing import Any, Optional
+
+import aws_kinesis_agg
+import pytest
+from aws_kinesis_agg.aggregator import RecordAggregator
+
+from handlers.aws.kinesis_deaggregation import deaggregate_kinesis_records
+
+_KPL_MAGIC: bytes = aws_kinesis_agg.MAGIC
+
+
+def _lambda_kinesis_record(data: bytes, partition_key: str = "partition-key") -> dict[str, Any]:
+    """Builds a kinesis record shaped the way AWS Lambda delivers it."""
+    return {
+        "kinesis": {
+            "kinesisSchemaVersion": "1.0",
+            "partitionKey": partition_key,
+            "sequenceNumber": "49568167373333333333333333333333333333333333333333333333",
+            "data": base64.b64encode(data).decode("utf-8"),
+            "approximateArrivalTimestamp": 1618434587.036,
+        },
+        "eventSource": "aws:kinesis",
+        "eventVersion": "1.0",
+        "eventID": "shardId-000000000000:49568167373333333333333333333333333333333333333333333333",
+        "eventName": "aws:kinesis:record",
+        "invokeIdentityArn": "arn:aws:iam::123456789012:role/lambda-role",
+        "awsRegion": "eu-central-1",
+        "eventSourceARN": "arn:aws:kinesis:eu-central-1:123456789012:stream/test-esf-kinesis-stream",
+    }
+
+
+def _aggregate(payloads: list[bytes], partition_keys: Optional[list[str]] = None) -> bytes:
+    """Builds a real KPL aggregated record using the reference implementation."""
+    aggregator = RecordAggregator()
+    for n, payload in enumerate(payloads):
+        partition_key = partition_keys[n] if partition_keys is not None else f"partition-key-{n}"
+        aggregator.add_user_record(partition_key, payload)
+
+    _, _, data = aggregator.clear_and_get().get_contents()
+    assert isinstance(data, bytes)
+    return data
+
+
+def _aggregated_record(message: bytes) -> bytes:
+    """Frames a protobuf message as an aggregated record, digest included, so it is recognised."""
+    return _KPL_MAGIC + message + hashlib.md5(message).digest()
+
+
+def _length_delimited_field(field_number: int, value: bytes) -> bytes:
+    """Encodes a length delimited protobuf field. Only lengths below 128 are needed here."""
+    assert len(value) < 128
+    return bytes([field_number << 3 | 2, len(value)]) + value
+
+
+def _varint_field(field_number: int, value: int) -> bytes:
+    """Encodes a varint protobuf field. Only values below 128 are needed here."""
+    assert value < 128
+    return bytes([field_number << 3, value])
+
+
+def _access_log_payload(n: int) -> bytes:
+    """A payload shaped and sized like the access log lines these streams actually carry."""
+    return json.dumps(
+        {
+            "account_id": f"account-{n}",
+            "client_ip": f"203.0.113.{n % 256}",
+            "domain_name": f"host-{n}.example.invalid",
+            "event_timestamp": "2026-08-19T00:00:00Z",
+            "first_byte_delay": "0.001",
+            "referer": f"https://host-{n}.example.invalid/referer/path/{n}",
+            "request": f"GET /some/reasonably/long/request/path/{n}?query=value&other=value HTTP/1.1",
+            "request_bytes": "512",
+            "request_method": "GET",
+            "request_scheme": "https",
+            "response_bytes": "2048",
+            "response_code": "200",
+            "server": f"server-{n}",
+            "server_ip": f"198.51.100.{n % 256}",
+            "server_response_time": "0.010",
+            "user_agent": "Mozilla/5.0 (compatible; ExampleBot/1.0; +https://example.invalid/bot)",
+            "x_powered_by": "PHP/8.2.0",
+        }
+    ).encode("utf-8")
+
+
+def _readable_message() -> bytes:
+    """A protobuf message that on its own resolves to exactly one user record."""
+    user_record = _varint_field(1, 0) + _length_delimited_field(3, b'{"msg":"one"}')
+
+    return _length_delimited_field(1, b"partition-key-0") + _length_delimited_field(3, user_record)
+
+
+def _aggregate_with_unresolvable_partition_key() -> bytes:
+    """
+    Builds an aggregated record whose digest is valid but whose partition key index points past the
+    partition key table, so its user records cannot be resolved.
+    """
+    # imported here because the module is only importable once aws_kinesis_agg has fixed up sys.path
+    from aws_kinesis_agg import messages_pb2
+
+    aggregated_record = messages_pb2.AggregatedRecord()
+    aggregated_record.partition_key_table.append("partition-key-0")
+    user_record = aggregated_record.records.add()
+    user_record.partition_key_index = 5
+    user_record.data = b'{"msg":"one"}'
+
+    message = aggregated_record.SerializeToString()
+    assert isinstance(message, bytes)
+    return _aggregated_record(message)
+
+
+@pytest.mark.unit
+class TestDeaggregateKinesisRecords:
+    def test_aggregated_record_expands_into_its_user_records(self) -> None:
+        aggregated = _aggregate([b'{"msg":"one"}', b'{"msg":"two"}', b'{"msg":"three"}'])
+
+        deaggregated = deaggregate_kinesis_records([_lambda_kinesis_record(aggregated)])
+
+        assert [base64.b64decode(record["kinesis"]["data"]) for record in deaggregated] == [
+            b'{"msg":"one"}',
+            b'{"msg":"two"}',
+            b'{"msg":"three"}',
+        ]
+
+    def test_user_record_data_is_a_string_as_lambda_delivers_it(self) -> None:
+        aggregated = _aggregate([b'{"msg":"one"}'])
+
+        deaggregated = deaggregate_kinesis_records([_lambda_kinesis_record(aggregated)])
+
+        assert isinstance(deaggregated[0]["kinesis"]["data"], str)
+
+    def test_record_the_deaggregator_cannot_expand_is_not_dropped(self) -> None:
+        record = _lambda_kinesis_record(_aggregate_with_unresolvable_partition_key())
+
+        deaggregated = deaggregate_kinesis_records([record])
+
+        assert deaggregated == [record]
+
+    def test_deaggregation_failure_is_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        record = _lambda_kinesis_record(_aggregate_with_unresolvable_partition_key())
+
+        with caplog.at_level("ERROR"):
+            deaggregate_kinesis_records([record])
+
+        assert "cannot deaggregate kinesis record" in caplog.text
+
+    def test_record_that_was_not_aggregated_is_returned_untouched(self) -> None:
+        record = _lambda_kinesis_record(b'{"msg":"not aggregated"}')
+
+        assert deaggregate_kinesis_records([record]) == [record]
+
+    def test_payload_shorter_than_the_magic_header_is_returned_untouched(self) -> None:
+        record = _lambda_kinesis_record(b"ab")
+
+        assert deaggregate_kinesis_records([record]) == [record]
+
+    def test_payload_with_the_magic_header_but_no_digest_is_returned_untouched(self) -> None:
+        record = _lambda_kinesis_record(_KPL_MAGIC + b"too short to hold a digest")
+
+        assert deaggregate_kinesis_records([record]) == [record]
+
+    def test_aggregated_record_with_a_corrupted_digest_is_returned_untouched(self) -> None:
+        corrupted = bytearray(_aggregate([b'{"msg":"one"}']))
+        corrupted[-1] ^= 0xFF
+        record = _lambda_kinesis_record(bytes(corrupted))
+
+        assert deaggregate_kinesis_records([record]) == [record]
+
+    def test_user_records_carry_their_sub_sequence_number(self) -> None:
+        aggregated = _aggregate([b'{"msg":"one"}', b'{"msg":"two"}', b'{"msg":"three"}'])
+
+        deaggregated = deaggregate_kinesis_records([_lambda_kinesis_record(aggregated)])
+
+        assert [record["kinesis"]["subSequenceNumber"] for record in deaggregated] == [0, 1, 2]
+
+    def test_user_records_carry_the_partition_key_they_were_aggregated_with(self) -> None:
+        aggregated = _aggregate([b'{"msg":"one"}', b'{"msg":"two"}'], partition_keys=["first", "second"])
+
+        deaggregated = deaggregate_kinesis_records([_lambda_kinesis_record(aggregated)])
+
+        assert [record["kinesis"]["partitionKey"] for record in deaggregated] == ["first", "second"]
+
+    def test_user_records_keep_the_metadata_of_the_record_they_came_from(self) -> None:
+        record = _lambda_kinesis_record(_aggregate([b'{"msg":"one"}', b'{"msg":"two"}']))
+
+        deaggregated = deaggregate_kinesis_records([record])
+
+        for user_record in deaggregated:
+            assert user_record["eventSourceARN"] == record["eventSourceARN"]
+            assert user_record["awsRegion"] == record["awsRegion"]
+            assert user_record["kinesis"]["sequenceNumber"] == record["kinesis"]["sequenceNumber"]
+            assert (
+                user_record["kinesis"]["approximateArrivalTimestamp"]
+                == record["kinesis"]["approximateArrivalTimestamp"]
+            )
+
+    def test_user_records_with_a_binary_payload_are_not_corrupted(self) -> None:
+        # fluent-bit can compress what it sends: the payload of a user record is not always text
+        gzipped = gzip.compress(b'{"msg":"one"}')
+        aggregated = _aggregate([gzipped])
+
+        deaggregated = deaggregate_kinesis_records([_lambda_kinesis_record(aggregated)])
+
+        assert base64.b64decode(deaggregated[0]["kinesis"]["data"]) == gzipped
+
+    def test_aggregated_and_plain_records_in_the_same_batch_are_both_handled(self) -> None:
+        aggregated = _lambda_kinesis_record(_aggregate([b'{"msg":"one"}', b'{"msg":"two"}']))
+        plain = _lambda_kinesis_record(b'{"msg":"three"}')
+
+        deaggregated = deaggregate_kinesis_records([aggregated, plain])
+
+        assert [base64.b64decode(record["kinesis"]["data"]) for record in deaggregated] == [
+            b'{"msg":"one"}',
+            b'{"msg":"two"}',
+            b'{"msg":"three"}',
+        ]
+
+    def test_empty_batch_is_handled(self) -> None:
+        assert deaggregate_kinesis_records([]) == []
+
+    def test_aggregated_record_built_by_the_reference_implementation_is_expanded(self) -> None:
+        # captured from awslabs/kinesis-aggregation, so the format we accept is not defined by the
+        # same code that produces the aggregated records in the tests above
+        reference_aggregated_record = (
+            "84mawgoEcGstMAoEcGstMQoEcGstMhoTCAAaD3sibXNnIjoibGluZTAifRoTCAEaD3sibXNnIjoi"
+            "bGluZTEifRoTCAIaD3sibXNnIjoibGluZTIifZ8hyadI+v2KZPZrUGim6cQ="
+        )
+
+        deaggregated = deaggregate_kinesis_records(
+            [_lambda_kinesis_record(base64.b64decode(reference_aggregated_record))]
+        )
+
+        assert [
+            (record["kinesis"]["partitionKey"], base64.b64decode(record["kinesis"]["data"])) for record in deaggregated
+        ] == [
+            ("pk-0", b'{"msg":"line0"}'),
+            ("pk-1", b'{"msg":"line1"}'),
+            ("pk-2", b'{"msg":"line2"}'),
+        ]
+
+    def test_aggregated_record_carrying_no_user_record_is_not_dropped(self) -> None:
+        message = _length_delimited_field(1, b"partition-key-0")
+        record = _lambda_kinesis_record(_aggregated_record(message))
+
+        assert deaggregate_kinesis_records([record]) == [record]
+
+    def test_aggregated_record_with_a_field_overrunning_the_message_is_not_dropped(self) -> None:
+        # a length delimited field announcing more bytes than the message holds. It trails a user
+        # record that reads correctly, so the record is forwarded because of the damaged field and
+        # not merely because nothing could be read out of the message.
+        record = _lambda_kinesis_record(_aggregated_record(_readable_message() + bytes([1 << 3 | 2, 127])))
+
+        assert deaggregate_kinesis_records([record]) == [record]
+
+    def test_aggregated_record_with_an_unsupported_wire_type_is_not_dropped(self) -> None:
+        # wire type 3 belongs to the group encoding, which the schema does not use
+        record = _lambda_kinesis_record(_aggregated_record(_readable_message() + bytes([1 << 3 | 3])))
+
+        assert deaggregate_kinesis_records([record]) == [record]
+
+    def test_aggregated_record_with_an_unterminated_varint_is_not_dropped(self) -> None:
+        # every byte has its continuation bit set, so the varint never ends
+        record = _lambda_kinesis_record(_aggregated_record(_readable_message() + bytes([0x80] * 4)))
+
+        assert deaggregate_kinesis_records([record]) == [record]
+
+    def test_user_records_are_recovered_when_an_explicit_hash_key_table_is_present(self) -> None:
+        # the explicit hash key table is a field of the schema this reader has no use for
+        aggregator = RecordAggregator()
+        aggregator.add_user_record("partition-key-0", b'{"msg":"one"}', explicit_hash_key="0")
+        aggregator.add_user_record("partition-key-1", b'{"msg":"two"}', explicit_hash_key="1")
+        _, _, aggregated = aggregator.clear_and_get().get_contents()
+
+        deaggregated = deaggregate_kinesis_records([_lambda_kinesis_record(aggregated)])
+
+        assert [base64.b64decode(record["kinesis"]["data"]) for record in deaggregated] == [
+            b'{"msg":"one"}',
+            b'{"msg":"two"}',
+        ]
+
+    def test_user_records_are_recovered_whatever_order_the_fields_are_serialised_in(self) -> None:
+        # a partition key index has to be resolved against the complete table, so the user records
+        # cannot be built before every field of the message has been read
+        user_record = _varint_field(1, 1) + _length_delimited_field(3, b'{"msg":"one"}')
+        message = (
+            _length_delimited_field(3, user_record)
+            + _length_delimited_field(1, b"partition-key-0")
+            + _length_delimited_field(1, b"partition-key-1")
+        )
+
+        deaggregated = deaggregate_kinesis_records([_lambda_kinesis_record(_aggregated_record(message))])
+
+        assert len(deaggregated) == 1
+        assert deaggregated[0]["kinesis"]["partitionKey"] == "partition-key-1"
+        assert base64.b64decode(deaggregated[0]["kinesis"]["data"]) == b'{"msg":"one"}'
+
+    def test_user_records_longer_than_a_one_byte_length_are_recovered(self) -> None:
+        # an access log line runs to several hundred bytes, so its length in the protobuf message
+        # does not fit in a single varint byte the way the short payloads above do
+        payloads = [_access_log_payload(n) for n in range(80)]
+        assert min(len(payload) for payload in payloads) > 127
+
+        deaggregated = deaggregate_kinesis_records([_lambda_kinesis_record(_aggregate(payloads))])
+
+        assert [base64.b64decode(record["kinesis"]["data"]) for record in deaggregated] == payloads
+
+    def test_user_record_longer_than_a_two_byte_length_is_recovered(self) -> None:
+        # a length above 16383 needs a third varint byte
+        payload = b'{"msg":"' + b"x" * 20000 + b'"}'
+
+        deaggregated = deaggregate_kinesis_records([_lambda_kinesis_record(_aggregate([payload]))])
+
+        assert base64.b64decode(deaggregated[0]["kinesis"]["data"]) == payload
+
+    def test_user_records_that_can_be_read_survive_one_that_cannot(self) -> None:
+        # one user record pointing outside the partition key table must not cost the aggregated
+        # record every other user record it carries
+        readable = _varint_field(1, 0) + _length_delimited_field(3, b'{"msg":"one"}')
+        unreadable = _varint_field(1, 5) + _length_delimited_field(3, b'{"msg":"two"}')
+        message = (
+            _length_delimited_field(1, b"partition-key-0")
+            + _length_delimited_field(3, readable)
+            + _length_delimited_field(3, unreadable)
+        )
+
+        deaggregated = deaggregate_kinesis_records([_lambda_kinesis_record(_aggregated_record(message))])
+
+        assert [base64.b64decode(record["kinesis"]["data"]) for record in deaggregated] == [b'{"msg":"one"}']
+
+    def test_unreadable_user_records_are_reported_once_for_the_whole_record(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # one report per kinesis record, however many of its user records could not be read
+        readable = _varint_field(1, 0) + _length_delimited_field(3, b'{"msg":"one"}')
+        unreadable = _varint_field(1, 5) + _length_delimited_field(3, b'{"msg":"two"}')
+        message = (
+            _length_delimited_field(1, b"partition-key-0")
+            + _length_delimited_field(3, readable)
+            + _length_delimited_field(3, unreadable) * 3
+        )
+
+        with caplog.at_level("ERROR"):
+            deaggregate_kinesis_records([_lambda_kinesis_record(_aggregated_record(message))])
+
+        assert caplog.text.count("cannot read some user records") == 1

--- a/tests/handlers/aws/test_kinesis_trigger.py
+++ b/tests/handlers/aws/test_kinesis_trigger.py
@@ -1,0 +1,83 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+import base64
+from typing import Any, Optional
+
+import mock
+import pytest
+
+from handlers.aws.kinesis_trigger import _handle_kinesis_move, _handle_kinesis_record
+from handlers.aws.utils import INTEGRATION_SCOPE_GENERIC, expand_event_list_from_field_resolver
+from share import ExpandEventListFromField
+
+_INPUT_ID = "arn:aws:kinesis:eu-central-1:123456789012:stream/test-esf-kinesis-stream"
+
+
+def _kinesis_record(payload: bytes, subsequence_number: Optional[int] = None) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "kinesis": {
+            "kinesisSchemaVersion": "1.0",
+            "partitionKey": "partition-key",
+            "sequenceNumber": "4956816737333",
+            "data": base64.b64encode(payload).decode("utf-8"),
+            "approximateArrivalTimestamp": 1618434587.036,
+        },
+        "eventSourceARN": _INPUT_ID,
+        "awsRegion": "eu-central-1",
+    }
+
+    if subsequence_number is not None:
+        record["kinesis"]["subSequenceNumber"] = subsequence_number
+
+    return record
+
+
+def _events_for(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    expander = ExpandEventListFromField("", INTEGRATION_SCOPE_GENERIC, expand_event_list_from_field_resolver)
+
+    return [
+        es_event for es_event, _, _, _ in _handle_kinesis_record({"Records": records}, _INPUT_ID, expander, None, None)
+    ]
+
+
+@pytest.mark.unit
+class TestHandleKinesisRecord:
+    def test_sub_sequence_number_of_a_user_record_is_kept_in_the_event(self) -> None:
+        events = _events_for([_kinesis_record(b'{"msg":"one"}', subsequence_number=7)])
+
+        assert events[0]["fields"]["aws"]["kinesis"]["subsequence_number"] == 7
+
+    def test_record_without_a_sub_sequence_number_does_not_get_one(self) -> None:
+        events = _events_for([_kinesis_record(b'{"msg":"one"}')])
+
+        assert "subsequence_number" not in events[0]["fields"]["aws"]["kinesis"]
+
+
+@pytest.mark.unit
+class TestHandleKinesisMove:
+    def _sent_message_attributes(self, record: dict[str, Any]) -> dict[str, Any]:
+        sqs_client = mock.MagicMock()
+
+        _handle_kinesis_move(
+            sqs_client=sqs_client,
+            sqs_destination_queue="https://sqs.eu-central-1.amazonaws.com/123456789012/continuing-queue",
+            kinesis_record=record,
+            event_input_id=_INPUT_ID,
+            config_yaml="inputs: []",
+        )
+
+        message_attributes = sqs_client.send_message.call_args.kwargs["MessageAttributes"]
+        assert isinstance(message_attributes, dict)
+        return message_attributes
+
+    def test_sub_sequence_number_is_forwarded_to_the_continuing_queue(self) -> None:
+        message_attributes = self._sent_message_attributes(_kinesis_record(b'{"msg":"one"}', subsequence_number=7))
+
+        assert message_attributes["originalSubsequenceNumber"]["StringValue"] == "7"
+
+    def test_record_without_a_sub_sequence_number_does_not_forward_one(self) -> None:
+        message_attributes = self._sent_message_attributes(_kinesis_record(b'{"msg":"one"}'))
+
+        assert "originalSubsequenceNumber" not in message_attributes

--- a/tests/handlers/aws/test_sqs_trigger.py
+++ b/tests/handlers/aws/test_sqs_trigger.py
@@ -1,0 +1,64 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+import base64
+from typing import Any, Optional
+
+import pytest
+
+from handlers.aws.sqs_trigger import _handle_sqs_event
+from handlers.aws.utils import INTEGRATION_SCOPE_GENERIC, expand_event_list_from_field_resolver
+from share import ExpandEventListFromField
+
+_KINESIS_INPUT_ID = "arn:aws:kinesis:eu-central-1:123456789012:stream/test-esf-kinesis-stream"
+
+
+def _continuing_kinesis_sqs_record(payload: bytes, subsequence_number: Optional[int] = None) -> dict[str, Any]:
+    """Builds the sqs record the continuing queue holds for a kinesis data stream input."""
+    message_attributes: dict[str, Any] = {
+        "originalEventSourceARN": {"stringValue": _KINESIS_INPUT_ID, "dataType": "String"},
+        "originalStreamType": {"stringValue": "stream", "dataType": "String"},
+        "originalStreamName": {"stringValue": "test-esf-kinesis-stream", "dataType": "String"},
+        "originalPartitionKey": {"stringValue": "partition-key", "dataType": "String"},
+        "originalSequenceNumber": {"stringValue": "4956816737333", "dataType": "String"},
+        "originalApproximateArrivalTimestamp": {"stringValue": "1618434587.036", "dataType": "Number"},
+    }
+
+    if subsequence_number is not None:
+        message_attributes["originalSubsequenceNumber"] = {
+            "stringValue": str(subsequence_number),
+            "dataType": "Number",
+        }
+
+    return {
+        "messageId": "message-id",
+        "body": base64.b64encode(payload).decode("utf-8"),
+        "attributes": {"SentTimestamp": "1618434587036"},
+        "messageAttributes": message_attributes,
+        "eventSourceARN": "arn:aws:sqs:eu-central-1:123456789012:continuing-queue",
+    }
+
+
+def _events_for(sqs_record: dict[str, Any]) -> list[dict[str, Any]]:
+    expander = ExpandEventListFromField("", INTEGRATION_SCOPE_GENERIC, expand_event_list_from_field_resolver)
+
+    return [
+        es_event
+        for es_event, _, _ in _handle_sqs_event(
+            sqs_record, _KINESIS_INPUT_ID, expander, "kinesis-data-stream", None, None
+        )
+    ]
+
+
+@pytest.mark.unit
+class TestHandleSqsEventContinuingKinesisRecord:
+    def test_sub_sequence_number_is_restored_from_the_continuing_queue(self) -> None:
+        events = _events_for(_continuing_kinesis_sqs_record(b'{"msg":"one"}', subsequence_number=7))
+
+        assert events[0]["fields"]["aws"]["kinesis"]["subsequence_number"] == 7
+
+    def test_message_without_a_sub_sequence_number_does_not_get_one(self) -> None:
+        events = _events_for(_continuing_kinesis_sqs_record(b'{"msg":"one"}'))
+
+        assert "subsequence_number" not in events[0]["fields"]["aws"]["kinesis"]

--- a/tests/handlers/aws/test_utils.py
+++ b/tests/handlers/aws/test_utils.py
@@ -355,6 +355,52 @@ class TestRecordId(TestCase):
         generated_id = kinesis_record_id(relevant_fields_for_id)
         assert _utf8len(generated_id) <= MAX_ES_ID_SIZ_BYTES
 
+    def test_kinesis_id_is_unchanged_without_a_sub_sequence_number(self) -> None:
+        relevant_fields_for_id: dict[str, Any] = {
+            "fields": {
+                "log": {"offset": 0},
+                "aws": {
+                    "kinesis": {
+                        "type": "stream",
+                        "name": "test-esf-kinesis-stream",
+                        "partition_key": "partition-key",
+                        "sequence_number": "4956816737333",
+                    }
+                },
+            },
+            "meta": {"approximate_arrival_timestamp": 1618434587036},
+        }
+
+        assert kinesis_record_id(relevant_fields_for_id) == (
+            "1618434587036-622f9217553d471be801dd27e2dac45bfb7252b532a25bc380dcef1bd881f6a0"
+            "386f93fd33c53813a550c283cc6966c7-000000000000"
+        )
+
+    def test_kinesis_id_differs_per_sub_sequence_number(self) -> None:
+        # the user records of an aggregated record share the partition key and the sequence number of
+        # the record they were aggregated in, and each of them starts at offset zero, so the sub
+        # sequence number is the only thing that tells their ids apart
+        def relevant_fields_for_id(subsequence_number: int) -> dict[str, Any]:
+            return {
+                "fields": {
+                    "log": {"offset": 0},
+                    "aws": {
+                        "kinesis": {
+                            "type": "stream",
+                            "name": "test-esf-kinesis-stream",
+                            "partition_key": "partition-key",
+                            "sequence_number": "4956816737333",
+                            "subsequence_number": subsequence_number,
+                        }
+                    },
+                },
+                "meta": {"approximate_arrival_timestamp": 1618434587036},
+            }
+
+        generated_ids = {kinesis_record_id(relevant_fields_for_id(n)) for n in range(3)}
+
+        assert len(generated_ids) == 3
+
     def test_s3_id_less_than_512bytes(self) -> None:
         event_time: int = int(datetime.datetime.now(datetime.UTC).timestamp() * 1000)
         bucket_name: str = _get_random_string_of_size(MAX_BUCKET_NAME_CHARS)

--- a/tests/handlers/aws/utils.py
+++ b/tests/handlers/aws/utils.py
@@ -19,6 +19,7 @@ import time
 from copy import deepcopy
 from typing import Any, Union
 
+from aws_kinesis_agg.aggregator import RecordAggregator
 from botocore.client import BaseClient as BotoBaseClient
 
 from handlers.aws.utils import get_queue_url_from_sqs_arn
@@ -170,6 +171,28 @@ def _kinesis_put_records(client: BotoBaseClient, stream_name: str, records_data:
     client.put_records(Records=records, StreamName=stream_name)
 
 
+def _kinesis_put_aggregated_record(client: BotoBaseClient, stream_name: str, records_data: list[str]) -> None:
+    """
+    Put the given payloads in the stream as the user records of a single KPL aggregated record, the way
+    a producer with aggregation enabled sends them.
+    """
+    aggregator = RecordAggregator()
+    for n, data in enumerate(records_data):
+        aggregator.add_user_record(f"PartitionKey{n}", data)
+
+    partition_key, _, aggregated_data = aggregator.clear_and_get().get_contents()
+
+    client.put_records(
+        Records=[
+            {
+                "PartitionKey": partition_key,
+                "Data": base64.b64encode(aggregated_data).decode("utf-8"),
+            }
+        ],
+        StreamName=stream_name,
+    )
+
+
 def _kinesis_retrieve_event_from_kinesis_stream(
     client: BotoBaseClient, stream_name: str, stream_arn: str
 ) -> tuple[dict[str, Any], list[int]]:
@@ -210,6 +233,9 @@ def _kinesis_retrieve_event_from_kinesis_stream(
             kinesis_record[camel_case_key] = new_value
 
         kinesis_record["approximateArrivalTimestamp"] = kinesis_record["approximateArrivalTimestamp"].timestamp()
+
+        # get_records does not return it, while lambda always delivers it as part of a kinesis record
+        kinesis_record["kinesisSchemaVersion"] = "1.0"
 
         new_records.append(
             {


### PR DESCRIPTION
Type of change: **Enhancement**

## What does this PR do?

It adds support for the Kinesis Producer Library (KPL) aggregated record format on `kinesis-data-stream` inputs.

A producer with aggregation enabled — the KPL itself, or any producer using the same format, such as the `kinesis` output of [`aws-for-fluent-bit`](https://github.com/aws/amazon-kinesis-streams-for-fluent-bit) with `aggregation true` — packs multiple user records into a single Kinesis record. The record payload is a four byte format signature, followed by a protobuf `AggregatedRecord` message, followed by an MD5 digest of that message.

At present such a record is forwarded as a single event whose `message` field holds the serialised protobuf payload, rather than the log lines contained within it.

This change adds `handlers/aws/kinesis_deaggregation.py`, which expands aggregated records into their constituent user records at the start of the Kinesis flow. Each user record is returned in the same shape as a record delivered by Lambda, which is what keeps the change contained: the remainder of the flow, including the continuing and replay queues, continues to operate on one user record at a time and required no further modification.

A record is identified as aggregated by both the format signature and the digest of its payload. Checking the digest as well as the signature means a payload that merely begins with the same four bytes is not misread, and a truncated or corrupted record is rejected rather than partially parsed. Records sent without aggregation are forwarded unchanged, and no configuration is involved in either case, so behaviour is unaffected for streams that do not use aggregation.

### No additional runtime dependency

Recovering the user records requires four fields of a schema that has been stable since the format was introduced, so the protobuf message is decoded directly rather than by adding a protobuf runtime to the Lambda package. `requirements.txt` is unchanged. [awslabs/kinesis-aggregation](https://github.com/awslabs/kinesis-aggregation) is added to `requirements-tests.txt` only, where it constructs the aggregated records the decoder is verified against, so the format accepted is not defined by the same code that reads it.

### Event `_id` generation

The user records of an aggregated record all carry the partition key and the sequence number of the record they were aggregated into, and where each holds a single line they all begin at offset zero. Those are precisely the fields `kinesis_record_id` hashes into an event `_id`, so deaggregation on its own would assign every user record of an aggregated record the same `_id`. As events are indexed with the `create` operation, all but one would then be rejected as version conflicts, and a version conflict is not surfaced as an error.

This change therefore records the sub sequence number of each user record in `aws.kinesis.subsequence_number`, includes it when generating the `_id`, and carries it through the continuing queue as `originalSubsequenceNumber` so that the `_id` remains stable when a record is processed from that queue. It is omitted for records that were not aggregated, whose `_id` values are therefore byte for byte identical to before.

## Why is it important?

Aggregation is a throughput and cost optimisation: it is the difference between one `PutRecords` payload per log line and one per batch, which matters on high volume streams. On a production stream measured while preparing this change, every sampled record was aggregated, carrying approximately 50 user records on average and up to 1,084 in a single record. Without deaggregation that entire feed is delivered to {{es}} as opaque protobuf payloads, and the log lines it carries are not searchable.

The `_id` behaviour described above is worth noting independently. On the same stream, deaggregation without the sub sequence number would have indexed roughly one event in every fifty and discarded the remainder without reporting an error.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~ — no configuration is involved; detection is by format signature and digest
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md` and updated `share/version.py`, if my change requires a new release. — added as `v1.21.7`; happy to change the version or drop that commit if you would rather handle it in a release commit

## Author's Checklist

- [x] Branched from `main`; `black`, `flake8`, `isort`, `mypy --strict` and the license header check are all clean
- [x] 473 unit tests and 37 integration tests pass locally
- [x] Every guard introduced by this change is covered by a test that fails when the guard is removed
- [ ] `CONTRIBUTING.md` asks for an issue first. I could not find an open issue or pull request covering aggregated record support, so nothing here duplicates existing work, but I am glad to open one and move the discussion there if you would prefer that before reviewing the code

## How to test this PR locally

```bash
python -m venv venv && . venv/bin/activate
pip install -r requirements.txt -r requirements-lint.txt -r requirements-tests.txt
make unit-test
make integration-test
```

Unit tests are in `tests/handlers/aws/test_kinesis_deaggregation.py`. End to end coverage is in `tests/handlers/aws/test_integrations.py::TestLambdaHandlerIntegration::test_kinesis_data_stream_aggregated_record`, where a single aggregated record placed on a stream is indexed as ten separate documents with sub sequence numbers `0` to `9`.

To observe the current behaviour for comparison, construct an aggregated record with `aws_kinesis_agg.aggregator.RecordAggregator`, put it on a stream, and note that one event is indexed whose `message` field contains the protobuf payload.

## Related issues

None found covering aggregated record support. I am happy to open one if you would prefer to discuss the approach before reviewing the implementation.

## Use cases

* A stream written by `aws-for-fluent-bit` with `aggregation true`, which is the case that prompted this change.
* Any producer using the Kinesis Producer Library directly, including the Java KPL and the aggregated Kinesis output plugins for `fluentd`.
* Streams carrying both aggregated and plain records in the same batch, which are handled together in a single pass.
* Streams that do not use aggregation, whose behaviour is unchanged, including the `_id` values generated for their events.

## Logs

The Kinesis `trigger` log line reports both counts, which makes it straightforward to confirm the behaviour is active:

```json
{"message": "trigger", "kinesis_records": 12, "size": 970}
```

`kinesis_records` is the number of records delivered by Lambda and `size` is the number of user records to be processed. The two are equal when no record on the stream is aggregated.

A record whose digest matches but which cannot be decoded is reported and forwarded as received, rather than discarded:

```json
{"message": "cannot deaggregate kinesis record, forwarding it as it was received", "sequence_number": "...", "reason": "..."}
```

Individual user records that cannot be resolved are skipped and reported once per record rather than once each, so a producer writing partition key indices it has not populated cannot flood the log:

```json
{"message": "cannot read some user records of a kinesis record, skipping them", "skipped": 3, "user_records": 80, "reason": "..."}
```
